### PR TITLE
fix memory leak in BMaskProvider

### DIFF
--- a/BilibiliLive/Module/Personal/PersonalViewController.swift
+++ b/BilibiliLive/Module/Personal/PersonalViewController.swift
@@ -59,7 +59,7 @@ class PersonalViewController: UIViewController, BLTabBarContentVCProtocol {
             self?.present(UISearchContainerViewController(searchController: searchVC), animated: true)
         }))
         cellModels.append(CellModel(title: "关注UP", contentVC: FollowUpsViewController()))
-        cellModels.append(CellModel(title: "稍后在看", contentVC: ToViewViewController()))
+        cellModels.append(CellModel(title: "稍后再看", contentVC: ToViewViewController()))
         cellModels.append(CellModel(title: "历史记录", contentVC: HistoryViewController()))
         cellModels.append(CellModel(title: "每周必看", contentVC: WeeklyWatchViewController()))
         cellModels.append(CellModel(title: "Anime1", contentVC: Anime1ViewController()))


### PR DESCRIPTION
This is to fix the memory leak in https://github.com/yichengchen/ATV-Bilibili-demo/issues/43
The root cause is the use of `[NSScanner scanCharactersFromSet:intoString:]` in PocketSVG.
It seems to be an old memory issue with apple's implementation according to https://github.com/SVGKit/SVGKit/issues/129

The fix is to wrap it with `autoreleasepool`. This is a workaround, and maybe the proper fix should be in PocketSVG.

before:
![before](https://user-images.githubusercontent.com/4075761/212611880-1cfc143e-380a-42ee-8c2c-442fcfa5cc15.png)
after:
![after](https://user-images.githubusercontent.com/4075761/212611898-14d98413-6554-4743-b9f7-1b0fdff6f5d8.png)

