### PR TITLE
fix danmu mask out of sync with video

### DIFF
--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -213,7 +213,7 @@ extension VideoPlayerViewController {
                    let video = playData.dash.video.first,
                    let fps = info?.dm_mask?.fps, fps > 0
                 {
-                    maskProvider = BMaskProvider(info: mask, videoSize: CGSize(width: video.width ?? 0, height: video.height ?? 0), duration: playData.dash.duration)
+                    maskProvider = BMaskProvider(info: mask, videoSize: CGSize(width: video.width ?? 0, height: video.height ?? 0))
                 } else if Settings.vnMask {
                     maskProvider = VMaskProvider()
                 }


### PR DESCRIPTION
This PR is to fix https://github.com/yichengchen/ATV-Bilibili-demo/issues/45

There are two issues:
1. The mask FPS returned from API is not accurate. The number seems to be rounded down. When we assume the FPS is 29 while it's actually 30, the delay for the mask is exaggerated when the video plays on.
2. mask frames returned from the API don't match perfectly with the video frames, so if we just calculate the frame index, there's still a noticeable 1-2 seconds mismatch.

The fix is to store the mask frames ordered by timestamp, and when we need to show the mask, we use binary search to find the latest mask frame.
Also, a minor improvement is to start using the mask before the processing is finished, which decreases the loading time when we play the video from the beginning.
![Simulator Screen Shot - Apple TV - 2023-01-16 at 16 10 46](https://user-images.githubusercontent.com/4075761/212784775-9f02d5bc-a0a2-4831-95b4-d54990fb82c3.png)
