### PR TITLE
fix: dlna ip

### DIFF
--- a/BilibiliLive/Module/DLNA/BiliBiliUpnpDMR.swift
+++ b/BilibiliLive/Module/DLNA/BiliBiliUpnpDMR.swift
@@ -171,10 +171,13 @@ class BiliBiliUpnpDMR: NSObject {
                 let addrFamily = interface.ifa_addr.pointee.sa_family
                 if addrFamily == UInt8(AF_INET) {
                     let name = String(cString: interface.ifa_name)
-                    if name == "en0" || name == "en2" || name == "en3" || name == "en4" {
+                    if name == "en0" || name == "en1" || name == "en2" || name == "en3" || name == "en4" {
                         var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
                         getnameinfo(interface.ifa_addr, socklen_t(interface.ifa_addr.pointee.sa_len), &hostname, socklen_t(hostname.count), nil, socklen_t(0), NI_NUMERICHOST)
                         address = String(cString: hostname)
+                        if name == "en0" {
+                            break
+                        }
                     }
                 }
             }


### PR DESCRIPTION
2022 ATV4K 128G 有线接口是 en0、无线接口是 en1
- 取消对 en1 接口的过滤
- 在有线接口有值时跳出循环