### PR TITLE
update SettingsSwitchCell text color to black while isFocused

### DIFF
--- a/BilibiliLive/Module/Personal/SettingsViewController.swift
+++ b/BilibiliLive/Module/Personal/SettingsViewController.swift
@@ -220,4 +220,14 @@ extension SettingsViewController: UICollectionViewDataSource {
 class SettingsSwitchCell: UICollectionViewCell {
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var descLabel: UILabel!
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        if isFocused {
+            titleLabel.textColor = UIColor.black
+            descLabel.textColor = UIColor.black
+        } else {
+            titleLabel.textColor = UIColor.white
+            descLabel.textColor = UIColor.white
+        }
+    }
 }


### PR DESCRIPTION
As title, the cell background is set to white on focus, I think this change is help to see the text 