### PR TITLE
[Bugfix] Fix player rate is not sync with UI after playing next

### DIFF
--- a/BilibiliLive.xcodeproj/project.pbxproj
+++ b/BilibiliLive.xcodeproj/project.pbxproj
@@ -707,7 +707,7 @@
 				SDKROOT = appletvos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TVOS_DEPLOYMENT_TARGET = 14.3;
+				TVOS_DEPLOYMENT_TARGET = 16.0;
 			};
 			name = Debug;
 		};
@@ -762,7 +762,7 @@
 				SDKROOT = appletvos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TVOS_DEPLOYMENT_TARGET = 14.3;
+				TVOS_DEPLOYMENT_TARGET = 16.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -795,7 +795,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 15.0;
+				TVOS_DEPLOYMENT_TARGET = 16.0;
 			};
 			name = Debug;
 		};
@@ -826,7 +826,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "BilibiliLive/Supporting Files/BilibiliLive-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 15.0;
+				TVOS_DEPLOYMENT_TARGET = 16.0;
 			};
 			name = Release;
 		};

--- a/BilibiliLive/Component/Feed/FeedCollectionViewController.swift
+++ b/BilibiliLive/Component/Feed/FeedCollectionViewController.swift
@@ -116,10 +116,7 @@ class FeedCollectionViewController: UIViewController {
     }
 
     private var selfSizeingEnable: Bool {
-        if #available(tvOS 16.0, *) {
-            return true
-        }
-        return false
+        true
     }
 
     private func makeGridLayoutSection() -> NSCollectionLayoutSection {

--- a/BilibiliLive/Component/Player/CommonPlayerViewController.swift
+++ b/BilibiliLive/Component/Player/CommonPlayerViewController.swift
@@ -204,14 +204,7 @@ class CommonPlayerViewController: AVPlayerViewController {
                 Settings.loopPlay = action.state == .on
             }
 
-            let playSpeedArray = [PlaySpeed(name: "0.5X", value: 0.5),
-                                  PlaySpeed(name: "0.75X", value: 0.75),
-                                  PlaySpeed(name: "1X", value: 1),
-                                  PlaySpeed(name: "1.25X", value: 1.25),
-                                  PlaySpeed(name: "1.5X", value: 1.5),
-                                  PlaySpeed(name: "2X", value: 2)]
-
-            let speedActions = playSpeedArray.map { playSpeed in
+            let speedActions = PlaySpeed.blDefaults.map { playSpeed in
                 UIAction(title: playSpeed.name, state: player?.rate ?? 1 == playSpeed.value ? .on : .off) { [weak self] _ in
                     self?.player?.currentItem?.audioTimePitchAlgorithm = .timeDomain
                     if #available(tvOS 16.0, *) {
@@ -411,4 +404,15 @@ extension CommonPlayerViewController: AVPlayerViewControllerDelegate {
 struct PlaySpeed {
     var name: String
     var value: Float
+}
+
+extension PlaySpeed {
+    static let blDefaults = [
+        PlaySpeed(name: "0.5X", value: 0.5),
+        PlaySpeed(name: "0.75X", value: 0.75),
+        PlaySpeed(name: "1X", value: 1),
+        PlaySpeed(name: "1.25X", value: 1.25),
+        PlaySpeed(name: "1.5X", value: 1.5),
+        PlaySpeed(name: "2X", value: 2),
+    ]
 }

--- a/BilibiliLive/Component/Player/CommonPlayerViewController.swift
+++ b/BilibiliLive/Component/Player/CommonPlayerViewController.swift
@@ -207,11 +207,7 @@ class CommonPlayerViewController: AVPlayerViewController {
             let speedActions = PlaySpeed.blDefaults.map { playSpeed in
                 UIAction(title: playSpeed.name, state: player?.rate ?? 1 == playSpeed.value ? .on : .off) { [weak self] _ in
                     self?.player?.currentItem?.audioTimePitchAlgorithm = .timeDomain
-                    if #available(tvOS 16.0, *) {
-                        self?.selectSpeed(AVPlaybackSpeed(rate: playSpeed.value, localizedName: playSpeed.name))
-                    } else {
-                        self?.player?.rate = playSpeed.value
-                    }
+                    self?.selectSpeed(AVPlaybackSpeed(rate: playSpeed.value, localizedName: playSpeed.name))
                     self?.danMuView.playingSpeed = playSpeed.value
                 }
             }

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -421,14 +421,10 @@ extension VideoPlayerViewController {
                 }
             }
         }
-        if #available(tvOS 16.0, *),
-           let defaultRate = self.player?.defaultRate,
-           let speed = PlaySpeed.blDefaults.first(where: { $0.value == defaultRate })
-        {
+        if let defaultRate = self.player?.defaultRate,
+           let speed = PlaySpeed.blDefaults.first(where: { $0.value == defaultRate }) {
             self.player = player
             selectSpeed(AVPlaybackSpeed(rate: speed.value, localizedName: speed.name))
-        } else {
-            self.player = player
         }
     }
 }

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -382,8 +382,8 @@ extension VideoPlayerViewController {
         }
 
         playerItem = AVPlayerItem(asset: asset)
-        player = AVPlayer(playerItem: playerItem)
-        player?.addPeriodicTimeObserver(forInterval: CMTime(seconds: 1, preferredTimescale: 1), queue: .main) { [weak self] time in
+        let player = AVPlayer(playerItem: playerItem)
+        player.addPeriodicTimeObserver(forInterval: CMTime(seconds: 1, preferredTimescale: 1), queue: .main) { [weak self] time in
             guard let self else { return }
             if self.danMuView.isHidden { return }
             let seconds = time.seconds
@@ -420,6 +420,15 @@ extension VideoPlayerViewController {
                     self.contextualActions = []
                 }
             }
+        }
+        if #available(tvOS 16.0, *),
+           let defaultRate = self.player?.defaultRate,
+           let speed = PlaySpeed.blDefaults.first(where: { $0.value == defaultRate })
+        {
+            self.player = player
+            selectSpeed(AVPlaybackSpeed(rate: speed.value, localizedName: speed.name))
+        } else {
+            self.player = player
         }
     }
 }


### PR DESCRIPTION
## Bug description & Steps to reproduce

For a video contains multi parts (eg. P1, P2 and P3). 

We set player's speed to 2x in P1 and then play to the next part.

The playSpeedMenu will still show 2x as "on" state not the actually 1x.

## Expected behavior

1. Reset the playSpeedMenu state after we update the player

or

2. Inherit the rate from the last player when setup a new AVPlayer.

Here I choose the second :)