### PR TITLE
Fix error when to view list is empty

### DIFF
--- a/BilibiliLive/Module/Personal/ToViewViewController.swift
+++ b/BilibiliLive/Module/Personal/ToViewViewController.swift
@@ -88,9 +88,9 @@ struct ToViewData: PlayableData, Codable {
 extension WebRequest {
     static func requestToView() async throws -> [ToViewData] {
         struct Resp: Codable {
-            var list: [ToViewData]
+            var list: [ToViewData]?
         }
         let res: Resp = try await request(url: "https://api.bilibili.com/x/v2/history/toview")
-        return res.list
+        return res.list ?? []
     }
 }


### PR DESCRIPTION
https://api.bilibili.com/x/v2/history/toview gives `list: null` when there's no videos to view.

```json
{
  "data" : {
    "count" : 0,
    "list" : null
  },
  "message" : "0",
  "ttl" : 1,
  "code" : 0
}
```