### PR TITLE
feat: 侧边栏菜单支持配置为自动选中，收藏页面调整为左右结构

### DIFF
--- a/BilibiliLive/Component/CategoryViewController.swift
+++ b/BilibiliLive/Component/CategoryViewController.swift
@@ -22,6 +22,16 @@ class CategoryViewController: UIViewController, BLTabBarContentVCProtocol {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        if categories.isEmpty {
+        } else {
+            initTypeCollectionView()
+        }
+    }
+
+    func initTypeCollectionView() {
+        if typeCollectionView != nil {
+            return
+        }
         typeCollectionView = UICollectionView(frame: .zero, collectionViewLayout: BLSettingLineCollectionViewCell.makeLayout())
         typeCollectionView.register(BLSettingLineCollectionViewCell.self, forCellWithReuseIdentifier: "cell")
         view.addSubview(typeCollectionView)

--- a/BilibiliLive/Component/CategoryViewController.swift
+++ b/BilibiliLive/Component/CategoryViewController.swift
@@ -12,6 +12,7 @@ class CategoryViewController: UIViewController, BLTabBarContentVCProtocol {
     struct CategoryDisplayModel {
         let title: String
         let contentVC: UIViewController
+        var autoSelect: Bool? = true
     }
 
     var typeCollectionView: UICollectionView!
@@ -73,5 +74,21 @@ extension CategoryViewController: UICollectionViewDataSource {
 extension CategoryViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         setViewController(vc: categories[indexPath.item].contentVC)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        if Settings.sideMenuAutoSelectChange == false {
+            return
+        }
+        guard let nextFocusedIndexPath = context.nextFocusedIndexPath else {
+            return
+        }
+        let categoryModel = categories[nextFocusedIndexPath.item]
+        if categoryModel.autoSelect == false {
+            // 不自动选中
+            return
+        }
+        collectionView.selectItem(at: nextFocusedIndexPath, animated: true, scrollPosition: .centeredHorizontally)
+        setViewController(vc: categoryModel.contentVC)
     }
 }

--- a/BilibiliLive/Component/Settings.swift
+++ b/BilibiliLive/Component/Settings.swift
@@ -92,6 +92,9 @@ enum Settings {
 
     @UserDefault("Settings.arealimit.customServer", defaultValue: "")
     static var areaLimitCustomServer: String
+
+    @UserDefault("Settings.ui.sideMenuAutoSelectChange", defaultValue: false)
+    static var sideMenuAutoSelectChange: Bool
 }
 
 struct MediaQuality {

--- a/BilibiliLive/Module/Personal/PersonalViewController.swift
+++ b/BilibiliLive/Module/Personal/PersonalViewController.swift
@@ -13,6 +13,7 @@ import UIKit
 struct CellModel {
     let title: String
     var desp: String? = nil
+    var autoSelect: Bool? = true
     var contentVC: UIViewController? = nil
     var action: (() -> Void)? = nil
 }
@@ -51,7 +52,7 @@ class PersonalViewController: UIViewController, BLTabBarContentVCProtocol {
     func setupData() {
         let setting = CellModel(title: "设置", contentVC: SettingsViewController.create())
         cellModels.append(setting)
-        cellModels.append(CellModel(title: "搜索", action: {
+        cellModels.append(CellModel(title: "搜索", autoSelect: false, action: {
             [weak self] in
             let resultVC = SearchResultViewController()
             let searchVC = UISearchController(searchResultsController: resultVC)
@@ -63,7 +64,7 @@ class PersonalViewController: UIViewController, BLTabBarContentVCProtocol {
         cellModels.append(CellModel(title: "历史记录", contentVC: HistoryViewController()))
         cellModels.append(CellModel(title: "每周必看", contentVC: WeeklyWatchViewController()))
 
-        let logout = CellModel(title: "登出") {
+        let logout = CellModel(title: "登出", autoSelect: false) {
             [weak self] in
             self?.actionLogout()
         }
@@ -116,6 +117,26 @@ extension PersonalViewController: UICollectionViewDataSource {
 extension PersonalViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let model = cellModels[indexPath.item]
+        if let vc = model.contentVC {
+            setViewController(vc: vc)
+        }
+        model.action?()
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didUpdateFocusIn context: UICollectionViewFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        if Settings.sideMenuAutoSelectChange == false {
+            return
+        }
+        // 检查新的焦点是否是UICollectionViewCell
+        guard let nextFocusedIndexPath = context.nextFocusedIndexPath else {
+            return
+        }
+        let model = cellModels[nextFocusedIndexPath.item]
+        if model.autoSelect == false {
+            // 不自动选中
+            return
+        }
+        collectionView.selectItem(at: nextFocusedIndexPath, animated: true, scrollPosition: .centeredHorizontally)
         if let vc = model.contentVC {
             setViewController(vc: vc)
         }

--- a/BilibiliLive/Module/Personal/SettingsViewController.swift
+++ b/BilibiliLive/Module/Personal/SettingsViewController.swift
@@ -182,6 +182,13 @@ class SettingsViewController: UIViewController {
         }
         cellModels.append(matchHdrOnly)
 
+        let sideMenuAutoSelectChange = CellModel(title: "侧边栏菜单自动切换", desp: Settings.sideMenuAutoSelectChange ? "开" : "关") {
+            [weak self] in
+            Settings.sideMenuAutoSelectChange.toggle()
+            self?.setupData()
+        }
+        cellModels.append(sideMenuAutoSelectChange)
+
         let areaLimitUnlock = CellModel(title: "解锁港澳台番剧限制", desp: Settings.areaLimitUnlock ? "开" : "关") {
             [weak self] in
             Settings.areaLimitUnlock.toggle()

--- a/BilibiliLive/Module/Personal/ToViewViewController.swift
+++ b/BilibiliLive/Module/Personal/ToViewViewController.swift
@@ -77,7 +77,10 @@ struct ToViewData: PlayableData, Codable {
     }
 
     var avatar: URL? {
-        return URL(string: owner.face)
+        if owner.face != nil {
+            return URL(string: owner.face!)
+        }
+        return nil
     }
 
     var date: String? {

--- a/BilibiliLive/Module/ViewController/FavoriteViewController.swift
+++ b/BilibiliLive/Module/ViewController/FavoriteViewController.swift
@@ -4,160 +4,57 @@
 //
 //  Created by whw on 2022/10/18.
 //
-
-import SnapKit
-import SwiftyJSON
+import Foundation
 import UIKit
 
-class FavoriteViewController: UIViewController {
-    var collectionView: UICollectionView!
-    var dataSource: UICollectionViewDiffableDataSource<FavListData, FavData>!
-    var currentSnapshot: NSDiffableDataSourceSnapshot<FavListData, FavData>!
+class FavoriteViewController: CategoryViewController {
     static let titleElementKind = "titleElementKind"
-    var reloading = false
 
     override func viewDidLoad() {
+        categories = []
         super.viewDidLoad()
-        collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
-        collectionView.delegate = self
-        tabBarObservedScrollView = collectionView
-        view.addSubview(collectionView)
-        collectionView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
-        configureDataSource()
-        reloadData()
-    }
 
-    @MainActor func applyData(for list: FavListData, content: [FavData]) {
-        currentSnapshot.appendItems(content, toSection: list)
-        dataSource.apply(currentSnapshot)
-    }
-}
-
-extension FavoriteViewController: BLTabBarContentVCProtocol {
-    func reloadData() {
-        if reloading { return }
-        reloading = true
-        defer {
-            reloading = false
-        }
         Task {
             guard let favList = try? await WebRequest.requestFavVideosList() else {
                 return
             }
-            currentSnapshot.deleteAllItems()
-            currentSnapshot.appendSections(favList)
-            favList.forEach { list in
-                Task {
-                    if let content = try? await WebRequest.requestFavVideos(mid: String(list.id), page: 1) {
-                        applyData(for: list, content: content)
-                    }
-                }
+            categories = favList.map {
+                return CategoryDisplayModel(title: $0.title, contentVC: FavoriteVideoContentViewController(info: $0))
             }
+
+            initTypeCollectionView()
+            print("收藏加载完成，数据量")
         }
     }
 }
 
-extension FavoriteViewController {
-    private func createLayout() -> UICollectionViewLayout {
-        let sectionProvider = {
-            (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                  heightDimension: .fractionalHeight(1))
-
-            let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            let hSpacing: CGFloat = Settings.displayStyle == .large ? 35 : 30
-            item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: hSpacing, bottom: 0, trailing: hSpacing)
-
-            let groupFractionalWidth = Settings.displayStyle.fractionalWidth
-            let groupFractionalHeight = Settings.displayStyle == .large ? 0.26 : 0.2
-
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(groupFractionalWidth),
-                                                   heightDimension: .fractionalWidth(groupFractionalHeight))
-            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-            group.edgeSpacing = .init(leading: .fixed(0), top: .fixed(40), trailing: .fixed(0), bottom: .fixed(10))
-            let section = NSCollectionLayoutSection(group: group)
-            section.orthogonalScrollingBehavior = .continuous
-
-            let titleSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                   heightDimension: .estimated(44))
-            let titleSupplementary = NSCollectionLayoutBoundarySupplementaryItem(
-                layoutSize: titleSize,
-                elementKind: FavoriteViewController.titleElementKind,
-                alignment: .top
-            )
-            section.boundarySupplementaryItems = [titleSupplementary]
-            return section
-        }
-
-        let config = UICollectionViewCompositionalLayoutConfiguration()
-        config.interSectionSpacing = 0
-
-        let layout = UICollectionViewCompositionalLayout(
-            sectionProvider: sectionProvider, configuration: config
-        )
-        return layout
+class FavoriteVideoContentViewController: StandardVideoCollectionViewController<FavData> {
+    let info: FavListData
+    init(info: FavListData) {
+        self.info = info
+        super.init(nibName: nil, bundle: nil)
     }
 
-    private func configureDataSource() {
-        let cellRegistration = UICollectionView.CellRegistration<FeedCollectionViewCell, FavData> {
-            $0.setup(data: $2)
-        }
-        dataSource = UICollectionViewDiffableDataSource<FavListData, FavData>(collectionView: collectionView, cellProvider: cellRegistration.cellProvider)
-
-        let supplementaryRegistration = UICollectionView.SupplementaryRegistration<TitleSupplementaryView>(elementKind: FavoriteViewController.titleElementKind) {
-            supplementaryView, string, indexPath in
-            if let snapshot = self.currentSnapshot {
-                let videoCategory = snapshot.sectionIdentifiers[indexPath.section]
-                supplementaryView.label.text = videoCategory.title
-            }
-        }
-
-        dataSource.supplementaryViewProvider = { view, kind, index in
-            return self.collectionView.dequeueConfiguredReusableSupplementary(
-                using: supplementaryRegistration, for: index
-            )
-        }
-
-        currentSnapshot = NSDiffableDataSourceSnapshot<FavListData, FavData>()
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-}
 
-extension FavoriteViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let d = dataSource.itemIdentifier(for: indexPath) else { return }
-        if let seasonId = d.ogv?.season_id {
+    override func setupCollectionView() {
+        collectionVC.styleOverride = .sideBar
+        super.setupCollectionView()
+    }
+
+    override func request(page: Int) async throws -> [FavData] {
+        return try await WebRequest.requestFavVideos(mid: String(info.id), page: page)
+    }
+
+    override func goDetail(with record: FavData) {
+        if let seasonId = record.ogv?.season_id {
             VideoDetailViewController.create(seasonId: seasonId).present(from: self)
         } else {
-            let vc = VideoDetailViewController.create(aid: d.id, cid: 0)
+            let vc = VideoDetailViewController.create(aid: record.id, cid: 0)
             vc.present(from: UIViewController.topMostViewController())
-        }
-    }
-
-    func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
-        if let section = currentSnapshot.sectionIdentifiers.first, currentSnapshot.numberOfItems(inSection: section) > 0 {
-            return IndexPath(item: 0, section: 0)
-        }
-        return nil
-    }
-
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        if collectionView.numberOfItems(inSection: indexPath.section) - 1 == indexPath.item {
-            if let ident = dataSource.sectionIdentifier(for: indexPath.section), !ident.loading, !ident.end {
-                Task {
-                    ident.currentPage += 1
-                    ident.loading = true
-                    defer { ident.loading = false }
-                    if let content = try? await WebRequest.requestFavVideos(mid: String(ident.id), page: ident.currentPage) {
-                        if content.count < 20 {
-                            ident.end = true
-                        }
-                        currentSnapshot.appendItems(content, toSection: ident)
-                        await dataSource.apply(currentSnapshot)
-                    }
-                }
-            }
         }
     }
 }

--- a/BilibiliLive/Module/ViewController/FavoriteViewController.swift
+++ b/BilibiliLive/Module/ViewController/FavoriteViewController.swift
@@ -23,7 +23,6 @@ class FavoriteViewController: CategoryViewController {
             }
 
             initTypeCollectionView()
-            print("收藏加载完成，数据量")
         }
     }
 }

--- a/BilibiliLive/Module/ViewController/FavoriteViewController.swift
+++ b/BilibiliLive/Module/ViewController/FavoriteViewController.swift
@@ -17,18 +17,20 @@ class FavoriteViewController: CategoryViewController {
         Task {
             // 用户创建的收藏夹
             let favList = try? await WebRequest.requestFavVideosList()
-            if favList != nil {
-                categories = favList!.map {
+            if let favList {
+                categories = favList.map {
                     return CategoryDisplayModel(title: $0.title, contentVC: FavoriteVideoContentViewController(info: $0))
                 }
             }
 
             // 用户收藏的订阅
             let favFolderCollectedList = try? await WebRequest.requestFavFolderCollectedList()
-            if favFolderCollectedList != nil {
-                favFolderCollectedList!.forEach {
-                    categories.append(CategoryDisplayModel(title: $0.title, contentVC: FavoriteVideoContentViewController(info: $0)))
-                }
+            if let favFolderCollectedList {
+                favFolderCollectedList
+                    .filter { $0.mid != 0 }
+                    .forEach {
+                        categories.append(CategoryDisplayModel(title: $0.title, contentVC: FavoriteVideoContentViewController(info: $0)))
+                    }
             }
 
             initTypeCollectionView()

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -553,13 +553,14 @@ struct FavData: PlayableData, Codable {
 class FavListData: Codable, Hashable {
     let title: String
     let id: Int
+    var mid: Int?
     var currentPage = 1
     var end = false
     var loading = false
     // 收藏夹是否为用户自己创建
     var createBySelf = false
     enum CodingKeys: String, CodingKey {
-        case title, id
+        case title, id, mid
     }
 
     static func == (lhs: FavListData, rhs: FavListData) -> Bool {

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -499,7 +499,7 @@ struct HistoryData: DisplayData, Codable {
 //    let bangumi: BangumiData?
 }
 
-struct FavData: DisplayData, Codable {
+struct FavData: PlayableData, Codable {
     var cover: String
     var upper: VideoOwner
     var id: Int
@@ -511,6 +511,14 @@ struct FavData: DisplayData, Codable {
 
     struct Ogv: Codable, Hashable {
         let season_id: Int?
+    }
+
+    var aid: Int {
+        return id
+    }
+
+    var cid: Int {
+        return 0
     }
 }
 


### PR DESCRIPTION
支持侧边菜单项获取焦点后自动展示右侧内容，现在是每次都需要点击一下确定才行，操作较为繁琐。
调整入口： `我的>设置>侧边栏菜单自动切换`
![HggScreenshot_20240206150954_6Loh3D3z](https://github.com/yichengchen/ATV-Bilibili-demo/assets/31559386/101f5901-658d-4dd5-b93e-8bffdb47012d)
