### PR TITLE
[Bug Fix] Fix auto play next episode starts from previous start timestamp

### DIFF
--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -163,6 +163,7 @@ class VideoPlayerViewController: CommonPlayerViewController {
     func playNext() -> Bool {
         if let next = nextProvider?.getNext() {
             playInfo = next
+            playerStartPos = 0
             Task {
                 await initPlayer()
             }


### PR DESCRIPTION
Steps to repro:
1. Play video and skip to timestamp A
2. Quit video
3. Play video again, should start from time A [expected]
4. Skip video to let it autoplay next episode
5. Next episode also starts from time A [Unexpected, should start from 0]

Fix: Reset start timestamp when auto play next episode