### PR TITLE
fix: optimize ugc_season selection logic

### DIFF
--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -321,7 +321,7 @@ class VideoDetailViewController: UIViewController {
 
         if let season = data.View.ugc_season {
             if season.sections.count > 1 {
-                season.sections.first(where: { section in section.episodes.contains(where: { episode in episode.aid == data.View.aid }) }).map { section in
+                if let section = season.sections.first(where: { section in section.episodes.contains(where: { episode in episode.aid == data.View.aid }) }) {
                     allUgcEpisodes = section.episodes
                 }
             } else {

--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -323,12 +323,11 @@ class VideoDetailViewController: UIViewController {
             if season.sections.count > 1 {
                 season.sections.first(where: { section in section.episodes.contains(where: { episode in episode.aid == data.View.aid }) }).map { section in
                     allUgcEpisodes = section.episodes
-                    allUgcEpisodes.sort { $0.arc.ctime < $1.arc.ctime }
                 }
             } else {
                 allUgcEpisodes = season.sections.first?.episodes ?? []
-                allUgcEpisodes.sort { $0.arc.ctime < $1.arc.ctime }
             }
+            allUgcEpisodes.sort { $0.arc.ctime < $1.arc.ctime }
         }
 
         ugcCollectionView.reloadData()

--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -320,8 +320,17 @@ class VideoDetailViewController: UIViewController {
         }
 
         if let season = data.View.ugc_season {
-            allUgcEpisodes = Array((season.sections.map { $0.episodes }.joined()))
+            if season.sections.count > 1 {
+                season.sections.first(where: { section in section.episodes.contains(where: { episode in episode.aid == data.View.aid }) }).map { section in
+                    allUgcEpisodes = section.episodes
+                    allUgcEpisodes.sort { $0.arc.ctime < $1.arc.ctime }
+                }
+            } else {
+                allUgcEpisodes = season.sections.first?.episodes ?? []
+                allUgcEpisodes.sort { $0.arc.ctime < $1.arc.ctime }
+            }
         }
+
         ugcCollectionView.reloadData()
         ugcLabel.text = "合集 \(data.View.ugc_season?.title ?? "")  \(data.View.ugc_season?.sections.first?.title ?? "")"
         ugcView.isHidden = allUgcEpisodes.count == 0

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -18,6 +18,7 @@ struct PlayInfo {
     var cid: Int? = 0
     var epid: Int? = 0 // 港澳台解锁需要
     var isBangumi: Bool = false
+    var ctime: Int? = 0
 
     var isCidVaild: Bool {
         return cid ?? 0 > 0

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -595,6 +595,7 @@ struct VideoDetail: Codable, Hashable {
         let ugc_season: UgcSeason?
         let redirect_url: URL?
         let stat: Stat
+        var ctime: Int?
         struct Stat: Codable, Hashable {
             let favorite: Int
             let coin: Int
@@ -623,6 +624,7 @@ struct VideoDetail: Codable, Hashable {
             struct UgcVideoInfo: Codable, Hashable, DisplayData {
                 var ownerName: String { "" }
                 var pic: URL? { arc.pic }
+                let id: Int
                 let aid: Int
                 let cid: Int
                 let arc: Arc
@@ -630,6 +632,7 @@ struct VideoDetail: Codable, Hashable {
 
                 struct Arc: Codable, Hashable {
                     let pic: URL
+                    let ctime: Int
                 }
             }
         }


### PR DESCRIPTION
I’m a beginner in `Swift`, so if there are any issues with the code, please let me know and I’ll make the changes.

* This resolves the issue mentioned in #96.
* After testing several `ugc_season` scenarios, I believe that when the `season` is greater than 1, a lookup should be performed. If the `season` equals 1, it should be used directly.
* Additionally, I have sorted the list based on `ctime`.