### PR TITLE
fix: DLNA play video instead of live when roomId=0

### DIFF
--- a/BilibiliLive/Module/DLNA/BiliBiliUpnpDMR.swift
+++ b/BilibiliLive/Module/DLNA/BiliBiliUpnpDMR.swift
@@ -257,7 +257,7 @@ class BiliBiliUpnpDMR: NSObject {
 
     func handlePlay(json: JSON) {
         let roomId = json["roomId"].stringValue
-        if roomId.count > 0, let room = Int(roomId) {
+        if roomId.count > 0, let room = Int(roomId), room > 0 {
             playLive(roomID: room)
         } else {
             playVideo(json: json)


### PR DESCRIPTION
Before:
|![556b830a9d73cb52392690da2672c922](https://github.com/yichengchen/ATV-Bilibili-demo/assets/15963765/ba75c886-cf7e-43c3-b6d8-adfa496070d7)|
|---|