### PR TITLE
ci: update GitHub actions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
     name: Build ipa
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload latest artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: main-unsigned.ipa
           path: BilbiliAtvDemo.ipa


### PR DESCRIPTION
- Now macos-latest is moved to macos-14.
- Bump actions to the latest, the old ones based on Node 16 are deprecated.