### PR TITLE
feat: 添加弹幕透明度相关设置，优化描边显示

### DIFF
--- a/BilibiliLive/Component/Settings.swift
+++ b/BilibiliLive/Component/Settings.swift
@@ -110,6 +110,15 @@ enum Settings {
 
     @UserDefault("Settings.danmuFilter", defaultValue: false)
     static var enableDanmuFilter: Bool
+
+    @UserDefaultCodable("Settings.danmuAlpha", defaultValue: .alpha_10)
+    static var danmuAlpha: DanmuAlpha
+
+    @UserDefaultCodable("Settings.danmuStrokeWidth", defaultValue: .width_20)
+    static var danmuStrokeWidth: DanmuStrokeWidth
+
+    @UserDefaultCodable("Settings.danmuStrokeAlpha", defaultValue: .alpha_08)
+    static var danmuStrokeAlpha: DanmuStrokeAlpha
 }
 
 struct MediaQuality {
@@ -168,6 +177,51 @@ enum DanmuSize: String, Codable, CaseIterable {
         case .size_57:
             return 57
         }
+    }
+}
+
+enum DanmuAlpha: Double, Codable, CaseIterable {
+    case alpha_03 = 0.3
+    case alpha_04 = 0.4
+    case alpha_05 = 0.5
+    case alpha_06 = 0.6
+    case alpha_07 = 0.7
+    case alpha_08 = 0.8
+    case alpha_09 = 0.9
+    case alpha_10 = 1.0
+    
+    var title: String {
+        return String(format: "%.1f", rawValue)
+    }
+}
+
+enum DanmuStrokeWidth: Double, Codable, CaseIterable {
+    case width_0 = 0.0
+    case width_05 = 0.5
+    case width_10 = 1.0
+    case width_15 = 1.5
+    case width_20 = 2.0
+    
+    var title: String {
+        return String(format: "%.1f", rawValue)
+    }
+}
+
+enum DanmuStrokeAlpha: Double, Codable, CaseIterable {
+    case alpha_00 = 0.0
+    case alpha_01 = 0.1
+    case alpha_02 = 0.2
+    case alpha_03 = 0.3
+    case alpha_04 = 0.4
+    case alpha_05 = 0.5
+    case alpha_06 = 0.6
+    case alpha_07 = 0.7
+    case alpha_08 = 0.8
+    case alpha_09 = 0.9
+    case alpha_10 = 1.0
+    
+    var title: String {
+        return String(format: "%.1f", rawValue)
     }
 }
 

--- a/BilibiliLive/Module/Personal/SettingsViewController.swift
+++ b/BilibiliLive/Module/Personal/SettingsViewController.swift
@@ -197,6 +197,30 @@ class SettingsViewController: UIViewController {
                 }
                 Toggle(title: "智能防档弹幕", setting: Settings.danmuMask, onChange: Settings.danmuMask.toggle())
                 Toggle(title: "按需本地运算智能防档弹幕(Exp)", setting: Settings.vnMask, onChange: Settings.vnMask.toggle())
+
+                // 添加弹幕透明度设置
+                Actions(title: "弹幕透明度", message: "调整弹幕的透明度",
+                        current: Settings.danmuAlpha.title,
+                        options: DanmuAlpha.allCases,
+                        optionString: DanmuAlpha.allCases.map({ $0.title })) { value in
+                    Settings.danmuAlpha = value
+                }
+
+                // 添加弹幕描边宽度设置
+                Actions(title: "弹幕描边宽度", message: "调整弹幕描边的粗细",
+                        current: Settings.danmuStrokeWidth.title,
+                        options: DanmuStrokeWidth.allCases,
+                        optionString: DanmuStrokeWidth.allCases.map({ $0.title })) { value in
+                    Settings.danmuStrokeWidth = value
+                }
+
+                // 添加弹幕描边透明度设置
+                Actions(title: "弹幕描边透明度", message: "调整弹幕描边的透明度",
+                        current: Settings.danmuStrokeAlpha.title,
+                        options: DanmuStrokeAlpha.allCases,
+                        optionString: DanmuStrokeAlpha.allCases.map({ $0.title })) { value in
+                    Settings.danmuStrokeAlpha = value
+                }
             }
 
             SectionModel(title: "港澳台解锁") {

--- a/BilibiliLive/Vendor/DanmakuKit/DanmakuTextCell.swift
+++ b/BilibiliLive/Vendor/DanmakuKit/DanmakuTextCell.swift
@@ -24,13 +24,15 @@ class DanmakuTextCell: DanmakuCell {
     override func displaying(_ context: CGContext, _ size: CGSize, _ isCancelled: Bool) {
         guard let model = model as? DanmakuTextCellModel else { return }
         let text = NSString(string: model.text)
-        context.setLineWidth(2)
+        context.setAlpha(CGFloat(Settings.danmuAlpha.rawValue))
+        context.setLineWidth(CGFloat(Settings.danmuStrokeWidth.rawValue))
         context.setLineJoin(.round)
         context.saveGState()
         context.setTextDrawingMode(.stroke)
 
-        let attributes: [NSAttributedString.Key: Any] = [.font: model.font, .foregroundColor: UIColor.black]
-        context.setStrokeColor(UIColor.black.cgColor)
+        let strokeColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: CGFloat(Settings.danmuStrokeAlpha.rawValue))
+        let attributes: [NSAttributedString.Key: Any] = [.font: model.font, .foregroundColor: strokeColor]
+        context.setStrokeColor(strokeColor.cgColor)
         text.draw(at: .zero, withAttributes: attributes)
         context.restoreGState()
 


### PR DESCRIPTION
大佬，我又来了，新加了一个弹幕透明度的设置，优化了下描边，
不过文件可能会和过滤重复弹幕有冲突（不知道为啥还没合入主分支🤔）。

以下是例子：
![image](https://github.com/user-attachments/assets/c27ff5b6-4442-41a5-ab3a-a504c4573763)
这是设置：
![image](https://github.com/user-attachments/assets/c364f550-87f2-45c4-95a9-9e5a6c5a5d6f)
这是默认值的时候的效果：
![image](https://github.com/user-attachments/assets/0fe19bac-e5d8-4e1e-a634-2beb0c08e26f)
