### PR TITLE
Add multi-account login management and switch UI

### DIFF
--- a/BilibiliLive/AccountManager.swift
+++ b/BilibiliLive/AccountManager.swift
@@ -1,0 +1,252 @@
+import Foundation
+import SwiftyJSON
+
+final class AccountManager {
+    struct Profile: Codable, Equatable {
+        let mid: Int
+        var username: String
+        var avatar: String
+    }
+
+    struct Account: Codable, Equatable {
+        var token: LoginToken
+        var profile: Profile
+        var cookies: [StoredCookie]
+        var lastActiveAt: Date
+    }
+
+    static let shared = AccountManager()
+    static let didUpdateNotification = Notification.Name("AccountManagerDidUpdate")
+
+    private let accountsKey = "app.multiple.accounts"
+    private let activeKey = "app.multiple.accounts.active"
+    private let storage = UserDefaults.standard
+
+    private var storedAccounts: [Account] = []
+    private var activeMID: Int?
+
+    private init() {
+        loadFromStorage()
+    }
+
+    // MARK: - Public
+
+    var accounts: [Account] {
+        storedAccounts.sorted(by: { $0.lastActiveAt > $1.lastActiveAt })
+    }
+
+    var activeAccount: Account? {
+        guard let activeMID else { return nil }
+        return storedAccounts.first(where: { $0.profile.mid == activeMID })
+    }
+
+    var isLoggedIn: Bool { activeAccount != nil }
+
+    func bootstrap() {
+        if activeAccount == nil, let first = storedAccounts.sorted(by: { $0.lastActiveAt > $1.lastActiveAt }).first {
+            activeMID = first.profile.mid
+            persistActiveMID()
+        }
+        applyActiveAccountCookies()
+    }
+
+    func registerAccount(token: LoginToken, cookies: [HTTPCookie], completion: @escaping (Account) -> Void) {
+        let storedCookies = cookies.map(StoredCookie.init)
+        fetchProfile { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                let profile: Profile
+                switch result {
+                case let .success(json):
+                    profile = Profile(mid: json["mid"].intValue,
+                                      username: json["uname"].stringValue,
+                                      avatar: json["face"].stringValue)
+                case .failure:
+                    profile = Profile(mid: token.mid,
+                                      username: "UID \(token.mid)",
+                                      avatar: "")
+                }
+                var newAccount = Account(token: token,
+                                         profile: profile,
+                                         cookies: storedCookies,
+                                         lastActiveAt: Date())
+                upsert(account: newAccount)
+                setActiveAccount(mid: newAccount.profile.mid, applyingCookies: false, notify: false)
+                updateAccount(mid: newAccount.profile.mid) { account in
+                    account.cookies = storedCookies
+                    account.lastActiveAt = Date()
+                    newAccount = account
+                }
+                applyActiveAccountCookies()
+                persistAll()
+                notifyChange()
+                completion(newAccount)
+            }
+        }
+    }
+
+    func setActiveAccount(_ account: Account) {
+        setActiveAccount(mid: account.profile.mid)
+    }
+
+    func setActiveAccount(mid: Int, applyingCookies: Bool = true, notify: Bool = true) {
+        guard storedAccounts.contains(where: { $0.profile.mid == mid }) else { return }
+        activeMID = mid
+        persistActiveMID()
+        updateAccount(mid: mid) { account in
+            account.lastActiveAt = Date()
+        }
+        if applyingCookies {
+            applyActiveAccountCookies()
+        }
+        persistAll()
+        if notify {
+            notifyChange()
+        }
+    }
+
+    func updateActiveAccount(token: LoginToken, cookies: [HTTPCookie]? = nil) {
+        guard let mid = activeAccount?.profile.mid else { return }
+        updateAccount(mid: mid) { account in
+            account.token = token
+            account.lastActiveAt = Date()
+            if let cookies {
+                account.cookies = cookies.map(StoredCookie.init)
+            }
+        }
+        persistAll()
+        notifyChange()
+    }
+
+    func updateActiveProfile(username: String, avatar: String) {
+        guard let mid = activeAccount?.profile.mid else { return }
+        updateAccount(mid: mid) { account in
+            account.profile.username = username
+            account.profile.avatar = avatar
+        }
+        persistAll()
+        notifyChange()
+    }
+
+    func refreshActiveAccountProfile() {
+        fetchProfile { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                switch result {
+                case let .success(json):
+                    self.updateActiveProfile(username: json["uname"].stringValue,
+                                             avatar: json["face"].stringValue)
+                case .failure:
+                    break
+                }
+            }
+        }
+    }
+
+    func syncActiveAccountCookies() {
+        guard let mid = activeAccount?.profile.mid else { return }
+        let cookies = CookieHandler.shared.currentStoredCookies()
+        updateAccount(mid: mid) { account in
+            account.cookies = cookies
+        }
+        persistAll()
+    }
+
+    @discardableResult
+    func removeAccount(_ account: Account) -> Bool {
+        storedAccounts.removeAll(where: { $0.profile.mid == account.profile.mid })
+        persistAccounts()
+        let removedActive = activeMID == account.profile.mid
+        if removedActive {
+            activeMID = nil
+            persistActiveMID()
+            if let next = storedAccounts.sorted(by: { $0.lastActiveAt > $1.lastActiveAt }).first {
+                setActiveAccount(mid: next.profile.mid)
+            } else {
+                CookieHandler.shared.removeCookie()
+                notifyChange()
+            }
+        } else {
+            notifyChange()
+        }
+        return !storedAccounts.isEmpty
+    }
+
+    func removeAllAccounts() {
+        storedAccounts.removeAll()
+        persistAccounts()
+        activeMID = nil
+        persistActiveMID()
+        CookieHandler.shared.removeCookie()
+        notifyChange()
+    }
+
+    func handleAuthenticationFailure() {
+        guard let account = activeAccount else { return }
+        _ = removeAccount(account)
+    }
+
+    // MARK: - Private helpers
+
+    private func fetchProfile(completion: @escaping (Result<JSON, RequestError>) -> Void) {
+        WebRequest.requestLoginInfo(complete: completion)
+    }
+
+    private func applyActiveAccountCookies() {
+        guard let cookies = activeAccount?.cookies else { return }
+        CookieHandler.shared.replaceCookies(with: cookies)
+    }
+
+    private func loadFromStorage() {
+        if let data = storage.data(forKey: accountsKey) {
+            do {
+                storedAccounts = try JSONDecoder().decode([Account].self, from: data)
+            } catch {
+                storedAccounts = []
+            }
+        }
+        if storage.object(forKey: activeKey) != nil {
+            let mid = storage.integer(forKey: activeKey)
+            activeMID = storedAccounts.contains(where: { $0.profile.mid == mid }) ? mid : nil
+        }
+    }
+
+    private func persistAll() {
+        persistAccounts()
+        persistActiveMID()
+    }
+
+    private func persistAccounts() {
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(storedAccounts) {
+            storage.set(data, forKey: accountsKey)
+        } else {
+            storage.removeObject(forKey: accountsKey)
+        }
+    }
+
+    private func persistActiveMID() {
+        if let activeMID {
+            storage.set(activeMID, forKey: activeKey)
+        } else {
+            storage.removeObject(forKey: activeKey)
+        }
+    }
+
+    private func upsert(account: Account) {
+        if let index = storedAccounts.firstIndex(where: { $0.profile.mid == account.profile.mid }) {
+            storedAccounts[index] = account
+        } else {
+            storedAccounts.append(account)
+        }
+    }
+
+    private func updateAccount(mid: Int, update: (inout Account) -> Void) {
+        guard let index = storedAccounts.firstIndex(where: { $0.profile.mid == mid }) else { return }
+        update(&storedAccounts[index])
+    }
+
+    private func notifyChange() {
+        NotificationCenter.default.post(name: AccountManager.didUpdateNotification, object: self)
+    }
+}

--- a/BilibiliLive/AppDelegate.swift
+++ b/BilibiliLive/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Logger.setup()
         AVInfoPanelCollectionViewThumbnailCellHook.start()
-        CookieHandler.shared.restoreCookies()
+        AccountManager.shared.bootstrap()
         BiliBiliUpnpDMR.shared.start()
         URLSession.shared.configuration.headers.add(.userAgent("BiLiBiLi AppleTV Client/1.0.0 (github/yichengchen/ATV-Bilibili-live-demo)"))
         window = UIWindow()

--- a/BilibiliLive/LoginViewController.swift
+++ b/BilibiliLive/LoginViewController.swift
@@ -92,10 +92,11 @@ class LoginViewController: UIViewController {
                 self.initValidation()
             case .waiting:
                 break
-            case let .success(token):
+            case let .success(token, cookies):
                 print(token)
-                UserDefaults.standard.set(codable: token, forKey: "token")
-                self.didValidationSuccess()
+                AccountManager.shared.registerAccount(token: token, cookies: cookies) { [weak self] _ in
+                    self?.didValidationSuccess()
+                }
             case .fail:
                 break
             }

--- a/BilibiliLive/Module/Personal/AccountSwitcherViewController.swift
+++ b/BilibiliLive/Module/Personal/AccountSwitcherViewController.swift
@@ -1,0 +1,357 @@
+import Kingfisher
+import UIKit
+
+final class AccountSwitcherViewController: UIViewController {
+    private enum Section: Int, CaseIterable {
+        case accounts
+        case actions
+    }
+
+    private let containerView = UIVisualEffectView(effect: UIBlurEffect(style: .systemChromeMaterialDark))
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let closeButton = UIButton(type: .system)
+    private lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumLineSpacing = 40
+        layout.minimumInteritemSpacing = 30
+        layout.sectionInset = UIEdgeInsets(top: 40, left: 60, bottom: 40, right: 60)
+        layout.itemSize = CGSize(width: 300, height: 320)
+        let collection = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collection.backgroundColor = .clear
+        collection.remembersLastFocusedIndexPath = true
+        collection.register(AccountSwitcherCell.self, forCellWithReuseIdentifier: AccountSwitcherCell.reuseIdentifier)
+        collection.register(AccountSwitcherAddCell.self, forCellWithReuseIdentifier: AccountSwitcherAddCell.reuseIdentifier)
+        collection.dataSource = self
+        collection.delegate = self
+        return collection
+    }()
+
+    private var accounts: [AccountManager.Account] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        setupContainer()
+        setupHeader()
+        setupCollectionView()
+        reloadData()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleAccountUpdate),
+                                               name: AccountManager.didUpdateNotification,
+                                               object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override var preferredFocusEnvironments: [UIFocusEnvironment] {
+        return [collectionView]
+    }
+
+    private func setupContainer() {
+        containerView.clipsToBounds = true
+        containerView.layer.cornerRadius = 36
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(containerView)
+        NSLayoutConstraint.activate([
+            containerView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            containerView.widthAnchor.constraint(equalToConstant: 1100),
+            containerView.heightAnchor.constraint(equalToConstant: 720),
+        ])
+    }
+
+    private func setupHeader() {
+        let contentView = containerView.contentView
+        titleLabel.text = "账号管理"
+        titleLabel.font = UIFont.systemFont(ofSize: 48, weight: .semibold)
+        titleLabel.textColor = .white
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        subtitleLabel.text = "快速切换登录账号或添加新的账号"
+        subtitleLabel.font = UIFont.systemFont(ofSize: 26, weight: .regular)
+        subtitleLabel.textColor = UIColor.white.withAlphaComponent(0.8)
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        closeButton.setTitle("关闭", for: .normal)
+        closeButton.setTitleColor(.white, for: .normal)
+        closeButton.titleLabel?.font = UIFont.systemFont(ofSize: 30, weight: .medium)
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.addTarget(self, action: #selector(closeTapped), for: .primaryActionTriggered)
+
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(subtitleLabel)
+        contentView.addSubview(closeButton)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 60),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 50),
+
+            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+
+            closeButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -60),
+            closeButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+        ])
+    }
+
+    private func setupCollectionView() {
+        let contentView = containerView.contentView
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            collectionView.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 30),
+        ])
+    }
+
+    private func reloadData() {
+        accounts = AccountManager.shared.accounts
+        collectionView.reloadData()
+    }
+
+    @objc private func closeTapped() {
+        dismiss(animated: true)
+    }
+
+    @objc private func handleAccountUpdate() {
+        reloadData()
+    }
+
+    private func presentLogin() {
+        dismiss(animated: true) {
+            AppDelegate.shared.showLogin()
+        }
+    }
+
+    private func switchToAccount(_ account: AccountManager.Account) {
+        AccountManager.shared.setActiveAccount(account)
+        AccountManager.shared.refreshActiveAccountProfile()
+        dismiss(animated: true)
+    }
+}
+
+extension AccountSwitcherViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        Section.allCases.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let section = Section(rawValue: section) else { return 0 }
+        switch section {
+        case .accounts:
+            return accounts.count
+        case .actions:
+            return 1
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let section = Section(rawValue: indexPath.section) else { return UICollectionViewCell() }
+        switch section {
+        case .accounts:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AccountSwitcherCell.reuseIdentifier, for: indexPath) as! AccountSwitcherCell
+            let account = accounts[indexPath.item]
+            cell.configure(with: account, active: account.profile.mid == AccountManager.shared.activeAccount?.profile.mid)
+            return cell
+        case .actions:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AccountSwitcherAddCell.reuseIdentifier, for: indexPath) as! AccountSwitcherAddCell
+            return cell
+        }
+    }
+}
+
+extension AccountSwitcherViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let section = Section(rawValue: indexPath.section) else { return }
+        switch section {
+        case .accounts:
+            let account = accounts[indexPath.item]
+            guard account.profile.mid != AccountManager.shared.activeAccount?.profile.mid else { return }
+            switchToAccount(account)
+        case .actions:
+            presentLogin()
+        }
+    }
+}
+
+private final class AccountSwitcherCell: UICollectionViewCell {
+    static let reuseIdentifier = "AccountSwitcherCell"
+
+    private let avatarView = UIImageView()
+    private let nameLabel = UILabel()
+    private let badgeLabel = UILabel()
+    private let background = UIView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        avatarView.image = nil
+        badgeLabel.isHidden = true
+        avatarView.backgroundColor = .clear
+        avatarView.tintColor = nil
+        background.layer.borderWidth = 0
+        background.transform = .identity
+    }
+
+    private func configure() {
+        contentView.clipsToBounds = false
+        background.translatesAutoresizingMaskIntoConstraints = false
+        background.backgroundColor = UIColor.white.withAlphaComponent(0.08)
+        background.layer.cornerRadius = 28
+        background.layer.borderWidth = 0
+        contentView.addSubview(background)
+
+        avatarView.translatesAutoresizingMaskIntoConstraints = false
+        avatarView.contentMode = .scaleAspectFill
+        avatarView.layer.cornerRadius = 80
+        avatarView.clipsToBounds = true
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.font = UIFont.systemFont(ofSize: 30, weight: .medium)
+        nameLabel.textColor = .white
+        nameLabel.textAlignment = .center
+        nameLabel.numberOfLines = 2
+
+        badgeLabel.translatesAutoresizingMaskIntoConstraints = false
+        badgeLabel.text = "当前使用"
+        badgeLabel.font = UIFont.systemFont(ofSize: 22, weight: .semibold)
+        badgeLabel.textColor = .white
+        badgeLabel.backgroundColor = UIColor.systemBlue
+        badgeLabel.layer.cornerRadius = 16
+        badgeLabel.clipsToBounds = true
+        badgeLabel.textAlignment = .center
+        badgeLabel.isHidden = true
+
+        background.addSubview(avatarView)
+        background.addSubview(nameLabel)
+        background.addSubview(badgeLabel)
+
+        NSLayoutConstraint.activate([
+            background.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            background.topAnchor.constraint(equalTo: contentView.topAnchor),
+            background.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            avatarView.centerXAnchor.constraint(equalTo: background.centerXAnchor),
+            avatarView.topAnchor.constraint(equalTo: background.topAnchor, constant: 36),
+            avatarView.widthAnchor.constraint(equalToConstant: 160),
+            avatarView.heightAnchor.constraint(equalTo: avatarView.widthAnchor),
+
+            nameLabel.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: 24),
+            nameLabel.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 16),
+            nameLabel.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -16),
+
+            badgeLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 16),
+            badgeLabel.centerXAnchor.constraint(equalTo: background.centerXAnchor),
+            badgeLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 140),
+            badgeLabel.heightAnchor.constraint(equalToConstant: 44),
+        ])
+    }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        let isFocused = (context.nextFocusedView == self)
+        coordinator.addCoordinatedAnimations {
+            self.background.layer.borderWidth = isFocused ? 4 : 0
+            self.background.layer.borderColor = isFocused ? UIColor.systemBlue.cgColor : UIColor.clear.cgColor
+            self.background.transform = isFocused ? CGAffineTransform(scaleX: 1.06, y: 1.06) : .identity
+        }
+    }
+
+    func configure(with account: AccountManager.Account, active: Bool) {
+        nameLabel.text = account.profile.username
+        if let url = URL(string: account.profile.avatar), !account.profile.avatar.isEmpty {
+            avatarView.kf.setImage(with: url)
+        } else {
+            avatarView.image = UIImage(systemName: "person.crop.circle.fill")
+            avatarView.tintColor = UIColor.white.withAlphaComponent(0.8)
+            avatarView.backgroundColor = UIColor.white.withAlphaComponent(0.05)
+        }
+        badgeLabel.isHidden = !active
+    }
+}
+
+private final class AccountSwitcherAddCell: UICollectionViewCell {
+    static let reuseIdentifier = "AccountSwitcherAddCell"
+
+    private let iconView = UIImageView()
+    private let titleLabel = UILabel()
+    private let background = UIView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        background.layer.borderWidth = 0
+        background.transform = .identity
+    }
+
+    private func configure() {
+        contentView.clipsToBounds = false
+        background.translatesAutoresizingMaskIntoConstraints = false
+        background.backgroundColor = UIColor.white.withAlphaComponent(0.08)
+        background.layer.cornerRadius = 28
+        contentView.addSubview(background)
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.contentMode = .scaleAspectFit
+        iconView.image = UIImage(systemName: "plus.circle.fill")
+        iconView.tintColor = .systemBlue
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.text = "添加账号"
+        titleLabel.font = UIFont.systemFont(ofSize: 30, weight: .medium)
+        titleLabel.textColor = .white
+        titleLabel.textAlignment = .center
+
+        background.addSubview(iconView)
+        background.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            background.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            background.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            background.topAnchor.constraint(equalTo: contentView.topAnchor),
+            background.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            iconView.topAnchor.constraint(equalTo: background.topAnchor, constant: 80),
+            iconView.centerXAnchor.constraint(equalTo: background.centerXAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 120),
+            iconView.heightAnchor.constraint(equalTo: iconView.widthAnchor),
+
+            titleLabel.topAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: background.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: background.trailingAnchor, constant: -16),
+        ])
+    }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        let isFocused = (context.nextFocusedView == self)
+        coordinator.addCoordinatedAnimations {
+            self.background.layer.borderWidth = isFocused ? 4 : 0
+            self.background.layer.borderColor = isFocused ? UIColor.systemBlue.cgColor : UIColor.clear.cgColor
+            self.background.transform = isFocused ? CGAffineTransform(scaleX: 1.06, y: 1.06) : .identity
+        }
+    }
+}

--- a/BilibiliLive/Request/ApiRequest.swift
+++ b/BilibiliLive/Request/ApiRequest.swift
@@ -32,25 +32,18 @@ enum ApiRequest {
     }
 
     enum LoginState {
-        case success(token: LoginToken)
+        case success(token: LoginToken, cookies: [HTTPCookie])
         case fail
         case expire
         case waiting
     }
 
-    static func save(token: LoginToken) {
-        UserDefaults.standard.set(token, forKey: "token")
-    }
-
     static func getToken() -> LoginToken? {
-        if let token: LoginToken = UserDefaults.standard.codable(forKey: "token") {
-            return token
-        }
-        return nil
+        return AccountManager.shared.activeAccount?.token
     }
 
     static func isLogin() -> Bool {
-        return getToken() != nil
+        return AccountManager.shared.isLoggedIn
     }
 
     static func sign(for param: [String: Any]) -> [String: Any] {
@@ -75,9 +68,12 @@ enum ApiRequest {
         return newParam
     }
 
-    static func logout(complete: (() -> Void)? = nil) {
-        UserDefaults.standard.removeObject(forKey: "token")
-        complete?()
+    static func logout(complete: ((Bool) -> Void)? = nil) {
+        var hasAccount = false
+        if let account = AccountManager.shared.activeAccount {
+            hasAccount = AccountManager.shared.removeAccount(account)
+        }
+        complete?(hasAccount)
     }
 
     static func requestJSON(_ url: URLConvertible,
@@ -100,8 +96,10 @@ enum ApiRequest {
                 let errorCode = json["code"].intValue
                 if errorCode != 0 {
                     if errorCode == -101 {
-                        UserDefaults.standard.removeObject(forKey: "token")
-                        AppDelegate.shared.showLogin()
+                        AccountManager.shared.handleAuthenticationFailure()
+                        if !AccountManager.shared.isLoggedIn {
+                            AppDelegate.shared.showLogin()
+                        }
                     }
                     let message = json["message"].stringValue
                     print(errorCode, message)
@@ -216,8 +214,9 @@ enum ApiRequest {
             switch result {
             case var .success(res):
                 res.tokenInfo.expireDate = Date().addingTimeInterval(TimeInterval(res.tokenInfo.expiresIn))
-                CookieHandler.shared.saveCookie(list: res.cookieInfo.toCookies())
-                handler?(.success(token: res.tokenInfo))
+                let cookies = res.cookieInfo.toCookies()
+                CookieHandler.shared.saveCookie(list: cookies)
+                handler?(.success(token: res.tokenInfo, cookies: cookies))
             case let .failure(error):
                 switch error {
                 case let .statusFail(code, _):
@@ -243,8 +242,9 @@ enum ApiRequest {
             switch result {
             case var .success(res):
                 res.tokenInfo.expireDate = Date().addingTimeInterval(TimeInterval(res.tokenInfo.expiresIn))
-                CookieHandler.shared.saveCookie(list: res.cookieInfo.toCookies())
-                UserDefaults.standard.set(codable: res.tokenInfo, forKey: "token")
+                let cookies = res.cookieInfo.toCookies()
+                CookieHandler.shared.saveCookie(list: cookies)
+                AccountManager.shared.updateActiveAccount(token: res.tokenInfo, cookies: cookies)
             case let .failure(err):
                 print(err)
             }


### PR DESCRIPTION
## Summary
- introduce a central AccountManager to persist multiple login tokens, cookies, and active account state
- integrate login, logout, token refresh, and cookie handling with the new multi-account model
- add an account switcher interface in the personal tab with updated avatar/username handling and multi-user actions

## Testing
- Not run (tvOS project requires an Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68e623448cf08324822bf926d3725a92