### PR TITLE
fix: fix bangumi history record display issue

### DIFF
--- a/BilibiliLive/Component/Video/NewVideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/NewVideoPlayerViewModel.swift
@@ -12,6 +12,7 @@ struct PlayerDetailData {
     let aid: Int
     let cid: Int
     let epid: Int? // 港澳台解锁需要
+    let seasonId: Int? // 番剧 season_id
     let isBangumi: Bool
 
     var playerStartPos: Int?
@@ -101,7 +102,7 @@ class VideoPlayerViewModel {
             let info = await infoReq
             _ = await detailUpdate
 
-            var detail = PlayerDetailData(aid: playInfo.aid, cid: playInfo.cid!, epid: playInfo.epid, isBangumi: playInfo.isBangumi, detail: videoDetail, clips: clipInfos, playerInfo: info, videoPlayURLInfo: playData)
+            var detail = PlayerDetailData(aid: playInfo.aid, cid: playInfo.cid!, epid: playInfo.epid, seasonId: playInfo.seasonId, isBangumi: playInfo.isBangumi, detail: videoDetail, clips: clipInfos, playerInfo: info, videoPlayURLInfo: playData)
 
             if let info, info.last_play_cid == cid, playData.dash.duration - info.playTimeInSecond > 5, Settings.continuePlay {
                 detail.playerStartPos = info.playTimeInSecond

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -33,7 +33,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
 
     func playerDidDismiss(playerVC: AVPlayerViewController) {
         guard let currentTime = playerVC.player?.currentTime().seconds, currentTime > 0 else { return }
-        WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime))
+        WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime), epid: playData.epid, seasonId: playData.seasonId, isBangumi: playData.isBangumi)
     }
 
     @MainActor

--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -460,10 +460,10 @@ extension VideoDetailViewController: UICollectionViewDelegate {
         switch collectionView {
         case pageCollectionView:
             let page = pages[indexPath.item]
-            let player = VideoPlayerViewController(playInfo: PlayInfo(aid: isBangumi ? page.page : aid, cid: page.cid, epid: page.epid, isBangumi: isBangumi))
+            let player = VideoPlayerViewController(playInfo: PlayInfo(aid: isBangumi ? page.page : aid, cid: page.cid, epid: page.epid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi))
             player.data = isBangumi ? nil : data
 
-            let seq = pages.dropFirst(indexPath.item).map({ PlayInfo(aid: aid, cid: $0.cid, isBangumi: isBangumi) })
+            let seq = pages.dropFirst(indexPath.item).map({ PlayInfo(aid: aid, cid: $0.cid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi) })
             if seq.count > 0 {
                 let nextProvider = VideoNextProvider(seq: seq)
                 player.nextProvider = nextProvider

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -13,6 +13,7 @@ struct PlayInfo {
     let aid: Int
     var cid: Int? = 0
     var epid: Int? = 0 // 港澳台解锁需要
+    var seasonId: Int? = 0 // 番剧 season_id
     var isBangumi: Bool = false
     var ctime: Int? = 0
 

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -34,6 +34,7 @@ enum WebRequest {
         static let favFolderCollectedList = "https://api.bilibili.com/x/v3/fav/folder/collected/list"
         static let favSeason = "https://api.bilibili.com/x/space/fav/season/list"
         static let reportHistory = "https://api.bilibili.com/x/v2/history/report"
+        static let heartbeat = "https://api.bilibili.com/x/click-interface/web/heartbeat"
         static let upSpace = "https://api.bilibili.com/x/space/wbi/arc/search"
         static let like = "https://api.bilibili.com/x/web-interface/archive/like"
         static let likeStatus = "https://api.bilibili.com/x/web-interface/archive/has/like"
@@ -341,10 +342,38 @@ extension WebRequest {
         return res.medias ?? []
     }
 
-    static func reportWatchHistory(aid: Int, cid: Int, currentTime: Int) {
+    static func reportWatchHistory(aid: Int, cid: Int, currentTime: Int, epid: Int? = nil, seasonId: Int? = nil, isBangumi: Bool = false) {
+        var parameters: [String: Any] = [
+            "aid": aid,
+            "cid": cid,
+            "played_time": currentTime,
+        ]
+
+        if isBangumi {
+            // 番剧类型标识
+            parameters["type"] = 4
+            parameters["sub_type"] = 1
+
+            // 番剧ID
+            if let epid = epid {
+                parameters["epid"] = epid
+            }
+            if let seasonId = seasonId {
+                parameters["sid"] = seasonId
+            }
+
+            // Web平台标识（关键：用于正确识别番剧历史记录）
+            parameters["mobi_app"] = "web"
+            parameters["device"] = "web"
+            parameters["platform"] = "web"
+        } else {
+            parameters["type"] = 3
+            parameters["sub_type"] = 0
+        }
+
         requestJSON(method: .post,
-                    url: EndPoint.reportHistory,
-                    parameters: ["aid": aid, "cid": cid, "progress": currentTime],
+                    url: EndPoint.heartbeat,
+                    parameters: parameters,
                     complete: nil)
     }
 


### PR DESCRIPTION
<img width="559" height="262" alt="image" src="https://github.com/user-attachments/assets/6a71ebc0-87b0-4a78-8fe9-96a3e67232da" />

左边的是之前的效果，右边的是心跳版本的效果，

心跳版本在移动端或者web端历史记录更干净。
不过如果从ATV版本的历史记录进去，因为入口参数和跳转逻辑的关系，这里记录历史还是会当做单个视频提交，回头有空且没人修的话修一下。。。