### PR TITLE
fix: 再次修正直播列表-352错误

### DIFF
--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -129,6 +129,13 @@ enum WebRequest {
                 if errorCode != 0 {
                     let message = json["message"].stringValue
                     print(errorCode, message)
+
+                    // Handle captcha validation error (-352)
+                    if errorCode == -352 {
+                        Logger.warn("WbiSign error (code=-352), clearing cache. URL: \(url)")
+                        WbiKeysCache.shared.clear()
+                    }
+
                     complete?(.failure(.statusFail(code: errorCode, message: message)))
                     return
                 }


### PR DESCRIPTION
发现出现-352后，只要从后台任务中删除app，重新进获取新的subkey和webid就能正常。这次修改改为缓存过期后同时刷新subkey和webid，当出现-352时就清空下缓存。