### PR TITLE
feat: 限制图片缓存大小为500MB

### DIFF
--- a/BilibiliLive/AppDelegate.swift
+++ b/BilibiliLive/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import AVFoundation
 import CocoaLumberjackSwift
+import Kingfisher
 import UIKit
 
 @main
@@ -15,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Logger.setup()
+        ImageCache.default.diskStorage.config.sizeLimit = 500 * 1024 * 1024
         AVInfoPanelCollectionViewThumbnailCellHook.start()
         AccountManager.shared.bootstrap()
         BiliBiliUpnpDMR.shared.start()


### PR DESCRIPTION
现在的图片缓存没大小限制，有时会占用超过10G，可能导致触发appletv的缓存清理机制