### PR TITLE
fix: 修正番剧继续播放和进度上报

### DIFF
--- a/BilibiliLive/Component/Video/NewVideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/NewVideoPlayerViewModel.swift
@@ -13,13 +13,17 @@ struct PlayerDetailData {
     let cid: Int
     let epid: Int? // 港澳台解锁需要
     let seasonId: Int? // 番剧 season_id
-    let isBangumi: Bool
+    let subType: Int? // 0: 普通视频 1：番剧 2：电影 3：纪录片 4：国创 5：电视剧 7：综艺
 
     var playerStartPos: Int?
     var detail: VideoDetail?
     var clips: [VideoPlayURLInfo.ClipInfo]?
     var playerInfo: PlayerInfo?
     var videoPlayURLInfo: VideoPlayURLInfo
+
+    var isBangumi: Bool {
+        return epid ?? 0 > 0 || seasonId ?? 0 > 0
+    }
 }
 
 class VideoPlayerViewModel {
@@ -102,10 +106,12 @@ class VideoPlayerViewModel {
             let info = await infoReq
             _ = await detailUpdate
 
-            var detail = PlayerDetailData(aid: playInfo.aid, cid: playInfo.cid!, epid: playInfo.epid, seasonId: playInfo.seasonId, isBangumi: playInfo.isBangumi, detail: videoDetail, clips: clipInfos, playerInfo: info, videoPlayURLInfo: playData)
+            var detail = PlayerDetailData(aid: playInfo.aid, cid: playInfo.cid!, epid: playInfo.epid, seasonId: playInfo.seasonId, subType: playInfo.subType, detail: videoDetail, clips: clipInfos, playerInfo: info, videoPlayURLInfo: playData)
 
-            if let info, info.last_play_cid == cid, playData.dash.duration - info.playTimeInSecond > 5, Settings.continuePlay {
-                detail.playerStartPos = info.playTimeInSecond
+            let last_play_cid = playInfo.lastPlayCid ?? info?.last_play_cid ?? 0
+            let playTimeInSecond = playInfo.playTimeInSecond ?? info?.playTimeInSecond ?? 0
+            if last_play_cid == cid, playData.dash.duration - playTimeInSecond > 5, Settings.continuePlay {
+                detail.playerStartPos = playTimeInSecond
             }
 
             return detail

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -33,7 +33,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
 
     func playerDidDismiss(playerVC: AVPlayerViewController) {
         guard let currentTime = playerVC.player?.currentTime().seconds, currentTime > 0 else { return }
-        WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime), epid: playData.epid, seasonId: playData.seasonId, isBangumi: playData.isBangumi)
+        WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime), epid: playData.epid, seasonId: playData.seasonId, subType: playData.subType)
     }
 
     @MainActor

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -14,11 +14,17 @@ struct PlayInfo {
     var cid: Int? = 0
     var epid: Int? = 0 // 港澳台解锁需要
     var seasonId: Int? = 0 // 番剧 season_id
-    var isBangumi: Bool = false
     var ctime: Int? = 0
+    var subType: Int? = nil // 0: 普通视频 1：番剧 2：电影 3：纪录片 4：国创 5：电视剧 7：综艺
+    var lastPlayCid: Int?
+    var playTimeInSecond: Int?
 
     var isCidVaild: Bool {
         return cid ?? 0 > 0
+    }
+
+    var isBangumi: Bool {
+        return epid ?? 0 > 0 || seasonId ?? 0 > 0
     }
 }
 

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -133,7 +133,9 @@ enum WebRequest {
                     return
                 }
                 let dataj = json[dataObj]
-                print("\(url) response: \(json)")
+                #if DEBUG
+                    print("\(url) response: \(json)")
+                #endif
                 complete?(.success(dataj))
             case let .failure(err):
                 complete?(.failure(err))
@@ -260,8 +262,8 @@ extension WebRequest {
         return info
     }
 
-    static func requestBangumiInfo(seasonID: Int) async throws -> BangumiSeasonInfo {
-        let res: BangumiSeasonInfo = try await request(url: "https://api.bilibili.com/pgc/web/season/section", parameters: ["season_id": seasonID], dataObj: "result")
+    static func requestBangumiInfo(seasonID: Int) async throws -> BangumiInfo {
+        let res: BangumiInfo = try await request(url: "https://api.bilibili.com/pgc/view/web/season", parameters: ["season_id": seasonID], dataObj: "result")
         return res
     }
 
@@ -342,17 +344,17 @@ extension WebRequest {
         return res.medias ?? []
     }
 
-    static func reportWatchHistory(aid: Int, cid: Int, currentTime: Int, epid: Int? = nil, seasonId: Int? = nil, isBangumi: Bool = false) {
+    static func reportWatchHistory(aid: Int, cid: Int, currentTime: Int, epid: Int? = nil, seasonId: Int? = nil, subType: Int? = nil) {
         var parameters: [String: Any] = [
             "aid": aid,
             "cid": cid,
             "played_time": currentTime,
         ]
 
-        if isBangumi {
+        if epid ?? 0 > 0 || seasonId ?? 0 > 0 {
             // 番剧类型标识
             parameters["type"] = 4
-            parameters["sub_type"] = 1
+            parameters["sub_type"] = subType ?? 1
 
             // 番剧ID
             if let epid = epid {
@@ -887,9 +889,41 @@ struct BangumiInfo: Codable, Hashable {
         let cover: URL
         let long_title: String
         let title: String
+
+        enum CodingKeys: String, CodingKey {
+            case id, aid, cid, cover, long_title, title
+        }
+
+        init(from decoder: Swift.Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(Int.self, forKey: .id)
+            aid = try container.decode(Int.self, forKey: .aid)
+            cid = try container.decode(Int.self, forKey: .cid)
+            cover = try container.decode(URL.self, forKey: .cover)
+            long_title = try container.decodeIfPresent(String.self, forKey: .long_title) ?? ""
+            title = try container.decode(String.self, forKey: .title)
+        }
     }
 
+    struct UserStatus: Codable, Hashable {
+        struct Progress: Codable, Hashable {
+            let last_time: Int // 最后观看的时间进度 | 单位为秒
+            let last_ep_id: Int
+            let last_ep_index: String // 最后观看的标题
+        }
+
+        let progress: Progress?
+    }
+
+    struct Section: Codable, Hashable {
+        let episodes: [Episode]
+    }
+
+    let type: Int
+    let season_id: Int
     let episodes: [Episode] // 正片剧集列表
+    let user_status: UserStatus?
+    let section: [Section]?
 }
 
 struct BangumiSeasonView: Codable, Hashable {


### PR DESCRIPTION
现在的番剧上报没法和官方的app同步，官方的app需要准确上报seasonid, epid和subType。准确上报后，番剧的播放进度需要从/pgc/view/web/season接口获取，旧的/x/player/wbi/v2接口只能获取到普通视频的。