### PR TITLE
fix: 加载尺寸过大的头像时崩溃

### DIFF
--- a/BilibiliLive/Component/Feed/FeedCollectionViewCell.swift
+++ b/BilibiliLive/Component/Feed/FeedCollectionViewCell.swift
@@ -110,8 +110,9 @@ class FeedCollectionViewCell: BLMotionCollectionViewCell {
             imageView.kf.setImage(with: pic, options: [.processor(DownsamplingImageProcessor(size: CGSize(width: 360, height: 202))), .cacheOriginalImage])
         }
         if let avatar = data.avatar {
+            let resizedAvatar = avatar.deletingLastPathComponent().appending(component: avatar.lastPathComponent + "@240w_240h.jpg")
             avatarView.isHidden = false
-            avatarView.kf.setImage(with: avatar, options: [.processor(DownsamplingImageProcessor(size: CGSize(width: 80, height: 80))), .processor(RoundCornerImageProcessor(radius: .widthFraction(0.5))), .cacheSerializer(FormatIndicatedCacheSerializer.png)])
+            avatarView.kf.setImage(with: resizedAvatar, options: [.processor(DownsamplingImageProcessor(size: CGSize(width: 80, height: 80))), .processor(RoundCornerImageProcessor(radius: .widthFraction(0.5))), .cacheSerializer(FormatIndicatedCacheSerializer.png)])
         } else {
             avatarView.isHidden = true
         }


### PR DESCRIPTION
目前加载的头像尺寸似乎是原图尺寸，但有些头像尺寸异常地大（如[马莉管家的头像](https://i2.hdslb.com/bfs/face/262511dc28fe5b386966028acdaad47cfaf95bf4.jpg)有惊人的 13620×13621 像素），可能导致内存占用过高被系统强行终止。

本 PR 参考 B 站网页端的做法，给头像 URL 添加 `@240w_240h.jpg` 来获得指定大小的缩略图。

对源代码还不熟悉，因此暂时只修改了直接导致崩溃的 `FeedCollectionViewCell`，可能其它位置也需要一同更改，以及 240 像素是否合适，还请确认下，辛苦了～