### PR TITLE
fix: 修复视频播放无限加载问题

### DIFF
--- a/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
+++ b/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
@@ -39,6 +39,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private var videoInfo = [PlaybackInfo]()
     private var segmentInfoCache = SidxDownloader()
     private var hasAudioInMasterListAdded = false
+    private var audioRenditionIndex = 0
     private(set) var playInfo: VideoPlayURLInfo?
     private var hasSubtitle = false
     private var hasPreferSubtitleAdded = false
@@ -60,6 +61,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
     private func reset() {
         playlists.removeAll()
+        audioRenditionIndex = 0
         masterPlaylist = """
         #EXTM3U
         #EXT-X-VERSION:6
@@ -173,9 +175,13 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
     private func addAudioPlayBackInfo(info: VideoPlayURLInfo.DashInfo.DashMediaInfo, url: String, duration: Int) {
         guard !videoCodecBlackList.contains(info.codecs) else { return }
-        let defaultStr = !hasAudioInMasterListAdded ? "YES" : "NO"
+        let isFirst = !hasAudioInMasterListAdded
+        hasAudioInMasterListAdded = true
+        let defaultStr = isFirst ? "YES" : "NO"
+        audioRenditionIndex += 1
+        let name = isFirst ? "Main" : "Main \(audioRenditionIndex)"
         let content = """
-        #EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=\(defaultStr),GROUP-ID="audio",NAME="Main",URI="\(URLs.customDashPrefix)\(videoInfo.count)"
+        #EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=\(defaultStr),GROUP-ID="audio",NAME="\(name)",URI="\(URLs.customDashPrefix)\(videoInfo.count)"
 
         """
 
@@ -184,10 +190,13 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     private func addAudioPlayBackInfo(codec: String, bandwidth: Int, duration: Int, url: String) {
-        let defaultStr = !hasAudioInMasterListAdded ? "YES" : "NO"
+        let isFirst = !hasAudioInMasterListAdded
         hasAudioInMasterListAdded = true
+        let defaultStr = isFirst ? "YES" : "NO"
+        audioRenditionIndex += 1
+        let name = isFirst ? "Main" : "Main \(audioRenditionIndex)"
         let content = """
-        #EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=\(defaultStr),GROUP-ID="audio",NAME="Main",URI="\(URLs.customPrefix)\(playlists.count)"
+        #EXT-X-MEDIA:TYPE=AUDIO,DEFAULT=\(defaultStr),GROUP-ID="audio",NAME="\(name)",URI="\(URLs.customPrefix)\(playlists.count)"
 
         """
         masterPlaylist.append(content)

--- a/BilibiliLive/Component/Video/Plugins/BVideoInfoPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoInfoPlugin.swift
@@ -16,7 +16,9 @@ class BVideoInfoPlugin: NSObject, CommonPlayerPlugin {
     var viewPoints: [PlayerInfo.ViewPoint]?
 
     func playerWillStart(player: AVPlayer) {
-        Task {
+        Task { @MainActor in
+            // Defer metadata setting to avoid Auto Layout conflicts
+            await Task.yield()
             async let info: () = AVPlayerMetaUtils.setPlayerInfo(title: title, subTitle: subTitle, desp: desp, pic: pic, player: player)
             if let viewPoints {
                 async let vp: () = updatePlayerCharpter(viewPoints: viewPoints, player: player)


### PR DESCRIPTION
fix: 修复视频播放无限加载问题
修复了 DASH 视频播放时出现的无限加载问题。

## 主要修复

### 1. 修复 sidx 解析问题
- 支持 sidx version 0 (32-bit) 和 version 1 (64-bit) 的正确解析
- 添加数据边界检查，防止越界读取
- 修复 extended size (size == 1) 的处理

### 2. 修复 HLS 播放列表生成问题
- 修复音频 rendition 名称重复导致的 CoreMediaErrorDomain -12642 错误
- 为每个音频轨道生成唯一名称（Main, Main 2, Main 3...）
- 确保只有第一个音频轨道设置为 DEFAULT=YES

### 3. 修复 UI 约束冲突
- 在设置播放器元数据前添加 Task.yield() 延迟
- 避免 AVKit 在布局未完成时应用 metadata 导致的约束冲突

## 问题描述

之前播放器在加载 Bilibili DASH 视频时会卡在 "waiting to minimize stalls" 状态，导致无限加载。通过分析发现两个关键问题：

1. HLS 播放列表中音频 rendition 名称重复
2. sidx 解析只支持 version 0，而 Bilibili 使用 version 1

## 测试

已在 Apple TV 上测试，视频可以正常播放。