### PR TITLE
feat: 添加播放器内画质选择器

### DIFF
--- a/BilibiliLive/Component/Player/Plugins/DanmuViewPlugin.swift
+++ b/BilibiliLive/Component/Player/Plugins/DanmuViewPlugin.swift
@@ -37,6 +37,7 @@ class DanmuViewPlugin: NSObject {
 
     private let danmuProvider: DanmuProviderProtocol
     private var timeObserver: Any?
+    private weak var currentPlayer: AVPlayer? // 保存当前 player 的弱引用
     private var cancellable = Set<AnyCancellable>()
 
     private func shoot(_ model: DanmakuCellModel) {
@@ -54,12 +55,36 @@ class DanmuViewPlugin: NSObject {
 }
 
 extension DanmuViewPlugin: CommonPlayerPlugin {
+    func playerDidChange(player: AVPlayer) {
+        // 清理旧的 observer（必须用旧的 player 来移除）
+        if let timeObserver, let currentPlayer {
+            currentPlayer.removeTimeObserver(timeObserver)
+            self.timeObserver = nil
+        }
+
+        // 保存新的 player 引用
+        currentPlayer = player
+
+        // 清空当前显示的弹幕，准备重新同步
+        danMuView.clean()
+    }
+
     func playerWillStart(player: AVPlayer) {
         guard danmuProvider.observerPlayerTime else {
             return
         }
-        player.addPeriodicTimeObserver(forInterval: CMTime(seconds: 1, preferredTimescale: 1),
-                                       queue: DispatchQueue.global())
+
+        // 清理旧的 observer（如果有）
+        if let timeObserver, let currentPlayer {
+            currentPlayer.removeTimeObserver(timeObserver)
+        }
+
+        // 保存新的 player 引用
+        currentPlayer = player
+
+        // 添加新的 observer 并保存引用
+        timeObserver = player.addPeriodicTimeObserver(forInterval: CMTime(seconds: 1, preferredTimescale: 1),
+                                                      queue: DispatchQueue.global())
         { [weak self] time in
             guard let self else { return }
             if !Defaults.shared.showDanmu { return }
@@ -71,7 +96,9 @@ extension DanmuViewPlugin: CommonPlayerPlugin {
     func playerDidCleanUp(player: AVPlayer) {
         if let timeObserver {
             player.removeTimeObserver(timeObserver)
+            self.timeObserver = nil
         }
+        currentPlayer = nil
     }
 
     func addViewToPlayerOverlay(container: UIView) {

--- a/BilibiliLive/Component/Player/SidxParseUtil.swift
+++ b/BilibiliLive/Component/Player/SidxParseUtil.swift
@@ -47,11 +47,11 @@ enum SidxParseUtil {
                 // size includes the 8-byte header (4 size + 4 type)
                 let boxDataSize = Int(size) - 8
                 let endIndex = Int(offset) + boxDataSize
-                
+
                 guard endIndex <= data.count else {
                     return nil
                 }
-                
+
                 sidx = processSIDX(data: Data(data[Int(offset)..<endIndex]))
                 offset += UInt64(boxDataSize)
             default:
@@ -72,7 +72,7 @@ enum SidxParseUtil {
         _ = data.getUint8(offset: &offset) // none
         _ = data.getUint32(offset: &offset) // refID
         let timescale = data.getUint32(offset: &offset)
-        
+
         // version 0: 32-bit, version 1: 64-bit
         let earliest_presentation_time: UInt64
         let first_offset: UInt64
@@ -83,7 +83,7 @@ enum SidxParseUtil {
             earliest_presentation_time = data.getValue(type: UInt64.self, offset: &offset).bigEndian
             first_offset = data.getValue(type: UInt64.self, offset: &offset).bigEndian
         }
-        
+
         _ = data.getValue(type: UInt16.self, offset: &offset).bigEndian // reversed
         let reference_count = data.getValue(type: UInt16.self, offset: &offset).bigEndian
 

--- a/BilibiliLive/Component/Video/NewVideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/NewVideoPlayerViewModel.swift
@@ -196,7 +196,14 @@ class VideoPlayerViewModel {
 
         playPlugin = player
 
-        var plugins: [CommonPlayerPlugin] = [player, danmu, playSpeed, upnp, debug, playlist]
+        // 添加画质选择器插件
+        let qualitySelector = BVideoQualityPlugin(detailData: data) { [weak player] qualityId, streamIndex in
+            Task { @MainActor in
+                await player?.switchQuality(to: qualityId, streamIndex: streamIndex)
+            }
+        }
+
+        var plugins: [CommonPlayerPlugin] = [player, danmu, playSpeed, upnp, debug, playlist, qualitySelector]
 
         if let clips = data.clips {
             let clip = BVideoClipsPlugin(clipInfos: clips)

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -11,9 +11,12 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     private weak var playerVC: AVPlayerViewController?
     private var playerDelegate: BilibiliVideoResourceLoaderDelegate?
     private let playData: PlayerDetailData
+    private var currentQualityId: Int?
+    private var currentPlaybackTime: Double = 0
 
     init(detailData: PlayerDetailData) {
         playData = detailData
+        currentQualityId = playData.videoPlayURLInfo.quality
     }
 
     func playerDidLoad(playerVC: AVPlayerViewController) {
@@ -37,7 +40,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     }
 
     @MainActor
-    private func playmedia(urlInfo: VideoPlayURLInfo, playerInfo: PlayerInfo?) async throws {
+    private func playmedia(urlInfo: VideoPlayURLInfo, playerInfo: PlayerInfo?, maxQuality: Int? = nil, streamIndex: Int? = nil, isQualitySwitch: Bool = false) async throws {
         let playURL = URL(string: BilibiliVideoResourceLoaderDelegate.URLs.play)!
         let headers: [String: String] = [
             "User-Agent": Keys.userAgent,
@@ -45,12 +48,17 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         ]
         let asset = AVURLAsset(url: playURL, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
         playerDelegate = BilibiliVideoResourceLoaderDelegate()
-        playerDelegate?.setBilibili(info: urlInfo, subtitles: playerInfo?.subtitle?.subtitles ?? [], aid: playData.aid)
-        if Settings.contentMatchOnlyInHDR {
-            if playerDelegate?.isHDR != true {
-                playerVC?.appliesPreferredDisplayCriteriaAutomatically = false
+        playerDelegate?.setBilibili(info: urlInfo, subtitles: playerInfo?.subtitle?.subtitles ?? [], aid: playData.aid, maxQuality: maxQuality, streamIndex: streamIndex)
+
+        // 只在初次加载时设置 appliesPreferredDisplayCriteriaAutomatically，切换画质时跳过
+        if !isQualitySwitch {
+            if Settings.contentMatchOnlyInHDR {
+                if playerDelegate?.isHDR != true {
+                    playerVC?.appliesPreferredDisplayCriteriaAutomatically = false
+                }
             }
         }
+
         asset.resourceLoader.setDelegate(playerDelegate, queue: DispatchQueue(label: "loader"))
         let playable = try await asset.load(.isPlayable)
         if !playable {
@@ -60,8 +68,38 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     }
 
     @MainActor
+    func switchQuality(to qualityId: Int, streamIndex: Int?) async {
+        guard let player = playerVC?.player else { return }
+
+        let currentTime = player.currentTime().seconds
+        guard currentTime > 0 else { return }
+
+        // 保存当前播放位置
+        currentPlaybackTime = currentTime
+        currentQualityId = qualityId
+
+        // 重新加载视频，使用新的画质
+        do {
+            try await playmedia(urlInfo: playData.videoPlayURLInfo, playerInfo: playData.playerInfo, maxQuality: qualityId, streamIndex: streamIndex, isQualitySwitch: true)
+
+            // 恢复播放位置并继续播放
+            if let newPlayer = playerVC?.player {
+                await newPlayer.seek(to: CMTime(seconds: currentPlaybackTime, preferredTimescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
+                newPlayer.play()
+            }
+        } catch {
+            Logger.warn("[quality] Failed to switch quality: \(error)")
+        }
+    }
+
+    @MainActor
     func prepare(toPlay asset: AVURLAsset) async {
         let playerItem = AVPlayerItem(asset: asset)
+
+        // 设置 preferredPeakBitRate 为一个很高的值，让 AVPlayer 优先选择高码率流
+        // 0 表示无限制，让 AVPlayer 根据网络条件自动选择最高可用码率
+        playerItem.preferredPeakBitRate = 0
+
         let player = AVPlayer(playerItem: playerItem)
         playerVC?.player = player
     }

--- a/BilibiliLive/Component/Video/Plugins/BVideoQualityPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoQualityPlugin.swift
@@ -1,0 +1,172 @@
+//
+//  BVideoQualityPlugin.swift
+//  BilibiliLive
+//
+
+import AVKit
+
+class BVideoQualityPlugin: NSObject, CommonPlayerPlugin {
+    private weak var playerVC: AVPlayerViewController?
+    private let playData: PlayerDetailData
+    private var availableQualities: [QualityOption] = []
+    private var currentQualityId: Int?
+    private var currentStreamIndex: Int? // 当前选中的流索引
+    private var isQualityLocked: Bool = false // 是否手动锁定了画质
+    private var onQualityChange: ((Int, Int?) -> Void)? // (qualityId, streamIndex)
+
+    struct QualityOption {
+        let id: Int
+        let name: String
+        let description: String
+        let bandwidth: Int // 该流的码率（bps）
+        let codec: String // 编码格式（如 avc1, hev1）
+        let streamIndex: Int? // 在 dash.video 数组中的索引（用于精确定位流）
+    }
+
+    init(detailData: PlayerDetailData, onQualityChange: @escaping (Int, Int?) -> Void) {
+        playData = detailData
+        self.onQualityChange = onQualityChange
+        super.init()
+
+        // 从 VideoPlayURLInfo 中提取可用画质
+        extractAvailableQualities()
+    }
+
+    func playerDidLoad(playerVC: AVPlayerViewController) {
+        self.playerVC = playerVC
+    }
+
+    private func extractAvailableQualities() {
+        let supportFormats = playData.videoPlayURLInfo.support_formats
+        let videoStreams = playData.videoPlayURLInfo.dash.video
+
+        // 为每个视频流创建一个 QualityOption
+        availableQualities = videoStreams.enumerated().map { index, stream in
+            // 尝试从 support_formats 中找到该画质的描述信息
+            let format = supportFormats.first { $0.quality == stream.id }
+            let baseName = format?.new_description ?? "画质 \(stream.id)"
+
+            // 提取编码类型（avc1 -> AVC, hev1 -> HEVC）
+            let codecType: String
+            if stream.codecs.starts(with: "avc") {
+                codecType = "AVC"
+            } else if stream.codecs.starts(with: "hev") || stream.codecs.starts(with: "hvc") {
+                codecType = "HEVC"
+            } else {
+                codecType = String(stream.codecs.prefix(4))
+            }
+
+            // 构建完整的名称：画质名称 (编码, 码率)
+            let mbps = Double(stream.bandwidth) / 1_000_000.0
+            let fullName = String(format: "%@ (%@, %.1f Mbps)", baseName, codecType, mbps)
+
+            return QualityOption(
+                id: stream.id,
+                name: fullName,
+                description: format?.display_desc ?? "",
+                bandwidth: stream.bandwidth,
+                codec: stream.codecs,
+                streamIndex: index
+            )
+        }
+
+        // 按画质 ID 降序排序，同画质按码率降序排序
+        availableQualities.sort {
+            if $0.id != $1.id {
+                return $0.id > $1.id
+            } else {
+                return $0.bandwidth > $1.bandwidth
+            }
+        }
+
+        // 设置当前画质为实际返回的画质
+        currentQualityId = playData.videoPlayURLInfo.quality
+    }
+
+    func addMenuItems(current: inout [UIMenuElement]) -> [UIMenuElement] {
+        guard !availableQualities.isEmpty else { return [] }
+
+        let qualityImage = UIImage(systemName: "video.fill")
+
+        // 按画质 ID 分组
+        let groupedQualities = Dictionary(grouping: availableQualities, by: { $0.id })
+
+        // 获取所有唯一的画质 ID 并排序
+        let sortedQualityIds = groupedQualities.keys.sorted(by: >)
+
+        // 为每个画质创建子菜单
+        let qualitySubmenus = sortedQualityIds.map { qualityId -> UIMenu in
+            let streams = groupedQualities[qualityId]!
+
+            // 获取画质的基础名称（去掉编码和码率信息）
+            let baseName: String
+            if let firstStream = streams.first {
+                // 从完整名称中提取基础名称（如 "4K 超高清 (AVC, 27.2 Mbps)" -> "4K 超高清"）
+                if let range = firstStream.name.range(of: " (") {
+                    baseName = String(firstStream.name[..<range.lowerBound])
+                } else {
+                    baseName = firstStream.name
+                }
+            } else {
+                baseName = "画质 \(qualityId)"
+            }
+
+            // 为该画质下的每个流创建菜单项
+            let streamActions = streams.map { quality -> UIAction in
+                // 检查是否是当前选中的流
+                let isCurrentStream = quality.streamIndex == currentStreamIndex && isQualityLocked
+
+                // 提取编码和码率信息（如 "AVC, 27.2 Mbps"）
+                let streamInfo: String
+                if let range = quality.name.range(of: " (") {
+                    let infoWithParens = String(quality.name[range.lowerBound...])
+                    streamInfo = infoWithParens.trimmingCharacters(in: CharacterSet(charactersIn: " ()"))
+                } else {
+                    let mbps = Double(quality.bandwidth) / 1_000_000.0
+                    streamInfo = String(format: "%.1f Mbps", mbps)
+                }
+
+                return UIAction(
+                    title: streamInfo,
+                    state: isCurrentStream ? .on : .off
+                ) { [weak self] _ in
+                    self?.switchQuality(to: quality)
+                }
+            }
+
+            // 如果只有一个流，显示完整信息
+            let menuTitle: String
+            if streams.count == 1, let stream = streams.first {
+                let mbps = Double(stream.bandwidth) / 1_000_000.0
+                menuTitle = String(format: "%@ (%.1f Mbps)", baseName, mbps)
+            } else {
+                menuTitle = baseName
+            }
+
+            return UIMenu(
+                title: menuTitle,
+                options: streams.count == 1 ? [] : [.displayInline],
+                children: streamActions
+            )
+        }
+
+        let qualityMenu = UIMenu(
+            title: "画质",
+            image: qualityImage,
+            identifier: UIMenu.Identifier(rawValue: "quality"),
+            children: qualitySubmenus
+        )
+
+        return [qualityMenu]
+    }
+
+    private func switchQuality(to quality: QualityOption) {
+        // 更新状态：标记为手动锁定
+        isQualityLocked = true
+        currentQualityId = quality.id
+        currentStreamIndex = quality.streamIndex
+
+        // 触发画质切换
+        onQualityChange?(quality.id, quality.streamIndex)
+    }
+}

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -462,26 +462,28 @@ extension WebRequest {
     }
 
     static func requestPlayUrl(aid: Int, cid: Int) async throws -> VideoPlayURLInfo {
-        let quality = Settings.mediaQuality
+        // 始终请求最高画质 (fnval=976 支持杜比视界和8K, qn=127 请求8K)
+        // 这样可以获取所有可用的画质流，由播放器或用户选择
         return try await request(url: EndPoint.playUrl,
-                                 parameters: ["avid": aid, "cid": cid, "qn": quality.qn, "type": "", "fnver": 0, "fnval": quality.fnval, "otype": "json"])
+                                 parameters: ["avid": aid, "cid": cid, "qn": 127, "type": "", "fnver": 0, "fnval": 976, "otype": "json"])
     }
 
     static func requestPcgPlayUrl(aid: Int, cid: Int) async throws -> VideoPlayURLInfo {
-        let quality = Settings.mediaQuality
+        // 始终请求最高画质 (fnval=976 支持杜比视界和8K, qn=127 请求8K)
+        // 这样可以获取所有可用的画质流，由播放器或用户选择
         return try await request(url: EndPoint.pcgPlayUrl,
-                                 parameters: ["avid": aid, "cid": cid, "qn": quality.qn, "support_multi_audio": true, "fnver": 0, "fnval": quality.fnval, "fourk": 1],
+                                 parameters: ["avid": aid, "cid": cid, "qn": 127, "support_multi_audio": true, "fnver": 0, "fnval": 976, "fourk": 1],
                                  dataObj: "result")
     }
 
     static func requestAreaLimitPcgPlayUrl(epid: Int, cid: Int, area: String) async throws -> VideoPlayURLInfo {
-        let quality = Settings.mediaQuality
         let customServer = Settings.areaLimitCustomServer
         guard !customServer.isEmpty else { throw ValidationError.argumentInvalid(message: "未设置解析服务器") }
 
         // 解析服务器必须使用ep_id参数，不能使用avid参数，解析服务器一般有缓存，area和ep_id必须保持一致，要不然会被缓存拦截
         let url = EndPoint.pcgPlayUrl.replacingOccurrences(of: "api.bilibili.com", with: customServer)
-        var parameters: [String: Any] = ["ep_id": epid, "cid": cid, "qn": quality.qn, "support_multi_audio": 1, "fnver": 0, "fnval": quality.fnval, "fourk": 1, "area": area]
+        // 始终请求最高画质 (fnval=976 支持杜比视界和8K, qn=127 请求8K)
+        var parameters: [String: Any] = ["ep_id": epid, "cid": cid, "qn": 127, "support_multi_audio": 1, "fnver": 0, "fnval": 976, "fourk": 1, "area": area]
         if let access_key = ApiRequest.getToken()?.accessToken {
             parameters["access_key"] = access_key
         }


### PR DESCRIPTION
## 概述

添加了播放器内的画质选择器功能，允许用户在视频播放过程中手动切换画质和视频流。

## 功能特性

### 核心功能
- 在播放器菜单中添加"画质"选项
- 支持播放过程中无缝切换画质
- 自动保存并恢复播放位置
- 显示详细的流信息（编码格式、码率）

### 用户界面
- 二级菜单设计：画质等级 → 具体视频流
- 每个画质等级下显示所有可用的编码和码率选项
  - 例如："4K 超高清" → "AVC, 27.2 Mbps" / "HEVC, 14.3 Mbps"
- 单一流的画质直接显示完整信息，无需展开子菜单
- 当前选中的流会显示勾选标记

### 智能画质模式
实现了三级画质选择策略：

1. **用户精确选择模式**：用户选择具体流时，强制使用该流
2. **画质锁定模式**：用户选择画质等级时，使用该画质的最高码率流
3. **自适应模式**（默认）：保留多级画质作为后备，让 AVPlayer 根据网络状况自动降级
   - 保留最高画质的所有编码
   - 保留中等画质（1080P）作为后备
   - 保留低画质（720P）作为紧急后备

## 主要改动

### 新增文件
- `BVideoQualityPlugin.swift` (172行)
  - 实现画质选择器插件
  - 提取并解析所有可用的视频流
  - 构建二级菜单UI
  - 处理用户选择并触发画质切换

### 核心修改

#### BVideoPlayPlugin.swift
- 添加 `switchQuality(to:streamIndex:)` 方法支持画质切换
- 保存当前播放位置，切换后自动恢复
- 添加 `isQualitySwitch` 参数，避免切换时重复设置显示模式
- 设置 `preferredPeakBitRate = 0` 让 AVPlayer 优先选择最高码率

#### BilibiliVideoResourceLoaderDelegate.swift
- 移除 `avc1.640034` 编码黑名单（现代设备已支持 H.264 High 5.2）
- 添加 `maxQuality` 和 `streamIndex` 参数支持精确流选择
- 实现智能画质过滤逻辑
- 优化音频流选择：只添加第一个 URL，避免菜单重复
- 为 HLS 音轨添加 `AUTOSELECT=YES` 和 `LANGUAGE="zh"` 属性
- 改进音轨命名：显示实际码率（如"音轨 (192kbps)"）

#### DanmuViewPlugin.swift
- 添加 `playerDidChange(player:)` 方法处理画质切换
- 保存 `currentPlayer` 弱引用用于正确清理 timeObserver
- 切换画质时清空弹幕，避免闪烁问题

#### WebRequest.swift
- 所有 API 请求统一使用 `qn=127, fnval=976` 获取最高画质列表
- 这样可以获取所有可用的画质流（包括杜比视界、8K），由播放器或用户选择

#### NewVideoPlayerViewModel.swift
- 初始化画质选择器插件并添加到插件列表
- 连接画质切换回调到 `BVideoPlayPlugin.switchQuality`

#### SidxParseUtil.swift
- 代码风格优化：删除尾随空格

## 技术细节

### 内存管理
- 正确使用 `weak` 引用避免循环引用
- 画质切换时正确清理旧的 timeObserver

### 播放体验
- 使用精确 seek（`toleranceBefore: .zero, toleranceAfter: .zero`）确保切换后位置准确
- 自动恢复播放状态（调用 `play()`）
- 保留 AVPlayer 的自适应码率能力

### HLS 优化
- 按码率降序排序流，让 AVPlayer 优先选择高码率
- 添加多个 CDN 节点 URL，让 AVPlayer 自动选择最快的节点
- 正确设置 HLS 音轨属性（AUTOSELECT, LANGUAGE）

## 兼容性

- 向后兼容：未选择画质时使用设置中的默认画质
- 不影响现有的自适应播放逻辑
- 支持所有现有的画质等级（360P - 8K）

## 相关 Issue

解决了用户无法在播放过程中手动切换画质的问题。