### PR TITLE
修正番剧花絮视频无法播放

### DIFF
--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -235,12 +235,12 @@ class VideoDetailViewController: UIViewController {
                     updatePlayProgressIfNeeded(progress: info.user_status?.progress, episode: epi)
                 }
             }
-            if !isBangumi, cid == 0, let page = data.View.pages?.first {
-                cid = page.cid
-            }
-            if !isBangumi, cid > 0, let page = data.View.pages?.first(where: { $0.cid == cid }) {
-                let playInfo = try await WebRequest.requestPlayerInfo(aid: aid, cid: cid)
-                if playInfo.last_play_cid == cid {
+            if !isBangumi {
+                let playInfo = try await WebRequest.requestPlayerInfo(aid: aid, cid: cid == 0 ? data.View.cid : cid)
+                if cid == 0 {
+                    cid = playInfo.last_play_cid > 0 ? playInfo.last_play_cid : data.View.cid
+                }
+                if playInfo.last_play_cid == cid, let page = data.View.pages?.first(where: { $0.cid == cid }) {
                     playTimeInSecond = playInfo.playTimeInSecond
                     lastPlayCid = playInfo.last_play_cid
                     lastPlayTitle = page.part

--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -212,7 +212,7 @@ class VideoDetailViewController: UIViewController {
                 let info = try await WebRequest.requestBangumiInfo(epid: epid)
                 seasonId = info.season_id
                 subType = info.type
-                if let epi = info.episodes.first(where: { $0.id == epid }) ?? info.episodes.first {
+                if let epi = info.findEpisodeById(epid) ?? info.episodes.first {
                     aid = epi.aid
                     cid = epi.cid
                     updatePlayProgressIfNeeded(progress: info.user_status?.progress, episode: epi)

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -933,6 +933,20 @@ struct BangumiInfo: Codable, Hashable {
     let episodes: [Episode] // 正片剧集列表
     let user_status: UserStatus?
     let section: [Section]?
+
+    func findEpisodeById(_ epid: Int) -> Episode? {
+        if let epi = episodes.first(where: { $0.id == epid }) {
+            return epi
+        }
+
+        for sec in section ?? [] {
+            if let epi = sec.episodes.first(where: { $0.id == epid }) {
+                return epi
+            }
+        }
+
+        return nil
+    }
 }
 
 struct BangumiSeasonView: Codable, Hashable {


### PR DESCRIPTION
现在番剧的花絮视频因为找不到数据而降级为第一集了，无法播放，这次修改为获取花絮数据并支持播放

还有修复了多P视频不默认继续播放指定part