### PR TITLE
Add 1.75x playback speed

### DIFF
--- a/BilibiliLive/Component/Player/Plugins/SpeedChangerPlugin.swift
+++ b/BilibiliLive/Component/Player/Plugins/SpeedChangerPlugin.swift
@@ -106,6 +106,7 @@ extension PlaySpeed: Equatable {
         PlaySpeed(name: "1X", value: 1),
         PlaySpeed(name: "1.25X", value: 1.25),
         PlaySpeed(name: "1.5X", value: 1.5),
+        PlaySpeed(name: "1.75X", value: 1.75),
         PlaySpeed(name: "2X", value: 2),
     ]
 }


### PR DESCRIPTION
## Summary
- Add a 1.75X playback speed option to the shared PlaySpeed defaults.
- Makes 1.75X available in both the player speed menu and the default playback speed setting.

## Validation
- git diff --check