### PR TITLE
perf: 提升播放流畅度；feat: UP 主空间支持按播放量排序

### DIFF
--- a/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
+++ b/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
@@ -127,14 +127,14 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     private func getVideoPlayList(info: PlaybackInfo) async -> String {
-        let segment = await segmentInfoCache.sidx(from: info.info)
+        let sidxResult = await segmentInfoCache.sidx(from: info.info)
         let inits = info.info.segment_base.initialization.components(separatedBy: "-")
         guard let moovIdxStr = inits.last,
               let moovIdx = Int(moovIdxStr),
               let moovOffset = inits.first,
               let offsetStr = info.info.segment_base.index_range.components(separatedBy: "-").last,
               var offset = Int(offsetStr),
-              let segment = segment
+              let sidxResult = sidxResult
         else {
             return """
             #EXTM3U
@@ -149,6 +149,10 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             """
         }
 
+        // 使用 sidx 实际下载成功的 URL——它已经完成了对 CDN 可用性的探测，
+        // 首选 CDN 挂掉时 segment 会整体切到探测成功的备用 URL
+        let segment = sidxResult.sidx
+        let segmentURL = sidxResult.url
         var playList = """
         #EXTM3U
         #EXT-X-VERSION:7
@@ -156,7 +160,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         #EXT-X-MEDIA-SEQUENCE:1
         #EXT-X-INDEPENDENT-SEGMENTS
         #EXT-X-PLAYLIST-TYPE:VOD
-        #EXT-X-MAP:URI="\(info.url)",BYTERANGE="\(moovIdx + 1)@\(moovOffset)"
+        #EXT-X-MAP:URI="\(segmentURL)",BYTERANGE="\(moovIdx + 1)@\(moovOffset)"
 
         """
         offset += 1
@@ -164,7 +168,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             let segStr = """
             #EXTINF:\(Double(segInfo.duration) / Double(segment.timescale)),
             #EXT-X-BYTERANGE:\(segInfo.size)@\(offset)
-            \(info.url)
+            \(segmentURL)
 
             """
             playList.append(segStr)
@@ -377,6 +381,15 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
         masterPlaylist.append("\n#EXT-X-ENDLIST\n")
 
+        // 预取 AVPlayer 大概率首选流（排序后第一条视频 + 默认音频）的 sidx，
+        // 与 master playlist 加载并行，缩短起播链路；actor 内有 in-progress 去重
+        let prefetchTargets = [videos.first, info.dash.audio?.first].compactMap { $0 }
+        for target in prefetchTargets {
+            Task.detached { [segmentInfoCache] in
+                _ = await segmentInfoCache.sidx(from: target)
+            }
+        }
+
         Logger.debug("masterPlaylist: \(masterPlaylist)")
     }
 
@@ -400,9 +413,9 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             return false
         }
 
-        DispatchQueue.main.async {
-            self.handleCustomPlaylistRequest(loadingRequest)
-        }
+        // 直接在 loader 串行队列处理，避免被主线程（弹幕渲染等）阻塞。
+        // playlist 相关状态在 setBilibili 中写入且发生在 setDelegate 之前，此处只读，无竞争。
+        handleCustomPlaylistRequest(loadingRequest)
         return true
     }
 }
@@ -478,24 +491,44 @@ enum BVideoUrlUtils {
         if let backup {
             urls.append(contentsOf: backup)
         }
-        return
-            urls.sorted { lhs, rhs in
-                let lhsIsPCDN = hasPort(lhs)
-                let rhsIsPCDN = hasPort(rhs)
-                switch (lhsIsPCDN, rhsIsPCDN) {
-                case (true, false): return false
-                case (false, true): return true
-                case (true, true): fallthrough
-                case (false, false): return lhs > rhs
-                }
-            }
+        // 按 tier 优选，同 tier 保持 API 返回顺序（enumerated + offset 实现稳定排序）
+        return urls.enumerated()
+            .sorted { (tier($0.element), $0.offset) < (tier($1.element), $1.offset) }
+            .map(\.element)
     }
 
-    static func hasPort(_ urlString: String) -> Bool {
+    // PCDN 特征：带端口，或已知的 P2P CDN 域名（部分 PCDN 域名不带端口，仅靠端口判断会漏）
+    static func isPCDN(_ urlString: String) -> Bool {
         guard let components = URLComponents(string: urlString) else {
             return false
         }
-        return components.port != nil
+        if components.port != nil {
+            return true
+        }
+        guard let host = components.host?.lowercased() else {
+            return false
+        }
+        return host.hasSuffix("szbdyd.com") || host.hasSuffix("mcdn.bilivideo.cn")
+    }
+
+    // CDN 质量分级：upos 主力节点最稳，akam 镜像走海外线路国内慢，PCDN 只作最后备援
+    private static func tier(_ urlString: String) -> Int {
+        if isPCDN(urlString) {
+            return 100
+        }
+        guard let host = URLComponents(string: urlString)?.host?.lowercased() else {
+            return 50
+        }
+        if host.hasPrefix("upos-"), host.hasSuffix(".bilivideo.com") {
+            return host.contains("akam") ? 30 : 0
+        }
+        if host.hasSuffix(".akamaized.net") {
+            return 40
+        }
+        if host.hasSuffix(".bilivideo.com") {
+            return 10
+        }
+        return 20
     }
 
     static func convertVTTFormate(_ time: CGFloat) -> String {
@@ -529,14 +562,28 @@ extension VideoPlayURLInfo.DashInfo.DashMediaInfo {
 }
 
 actor SidxDownloader {
-    private enum CacheEntry {
-        case inProgress(Task<SidxParseUtil.Sidx?, Never>)
-        case ready(SidxParseUtil.Sidx?)
+    struct SidxResult {
+        let sidx: SidxParseUtil.Sidx
+        let url: String
     }
+
+    private enum CacheEntry {
+        case inProgress(Task<SidxResult?, Never>)
+        case ready(SidxResult?)
+    }
+
+    // sidx 只有几 KB，用短超时的独立 Session，避免默认 60s 超时把起播卡死
+    private static let session: Session = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 6
+        config.timeoutIntervalForResource = 10
+        config.headers = HTTPHeaders(["User-Agent": Keys.userAgent])
+        return Session(configuration: config)
+    }()
 
     private var cache: [VideoPlayURLInfo.DashInfo.DashMediaInfo: CacheEntry] = [:]
 
-    func sidx(from info: VideoPlayURLInfo.DashInfo.DashMediaInfo) async -> SidxParseUtil.Sidx? {
+    func sidx(from info: VideoPlayURLInfo.DashInfo.DashMediaInfo) async -> SidxResult? {
         if let cached = cache[info] {
             switch cached {
             case let .ready(sidx):
@@ -560,16 +607,19 @@ actor SidxDownloader {
         return sidx
     }
 
-    private func downloadSidx(info: VideoPlayURLInfo.DashInfo.DashMediaInfo) async -> SidxParseUtil.Sidx? {
+    private func downloadSidx(info: VideoPlayURLInfo.DashInfo.DashMediaInfo) async -> SidxResult? {
         let range = info.segment_base.index_range
-        let url = info.playableURLs.first ?? info.base_url
-        if let res = try? await AF.request(url,
-                                           headers: ["Range": "bytes=\(range)",
-                                                     "Referer": "https://www.bilibili.com/"])
-            .serializingData().result.get()
-        {
-            let segment = SidxParseUtil.processIndexData(data: res)
-            return segment
+        for url in info.playableURLs.prefix(3) {
+            if let res = try? await Self.session.request(url,
+                                                         headers: ["Range": "bytes=\(range)",
+                                                                   "Referer": "https://www.bilibili.com/"])
+                .serializingData().result.get(),
+                let segment = SidxParseUtil.processIndexData(data: res),
+                !segment.segments.isEmpty
+            {
+                return SidxResult(sidx: segment, url: url)
+            }
+            Logger.warn("sidx download failed on \(url), try next url")
         }
         return nil
     }

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -100,6 +100,9 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         // 0 表示无限制，让 AVPlayer 根据网络条件自动选择最高可用码率
         playerItem.preferredPeakBitRate = 0
 
+        // 前向缓冲 60s，扛住 CDN 吞吐抖动减少卡顿（4K HDR ~25Mbps × 60s ≈ 190MB，可接受）
+        playerItem.preferredForwardBufferDuration = 60
+
         let player = AVPlayer(playerItem: playerItem)
         playerVC?.player = nil
         playerVC?.player = player

--- a/BilibiliLive/Component/View/UpSpaceTitleSupplementaryView.swift
+++ b/BilibiliLive/Component/View/UpSpaceTitleSupplementaryView.swift
@@ -14,10 +14,12 @@ class UpSpaceTitleSupplementaryView: UICollectionReusableView {
     let despLabel = UILabel()
     let followButton = BLCustomButton()
     let blockButton = BLCustomButton()
+    let sortButton = BLCustomButton()
     private let focusGuide = UIFocusGuide()
 
     var onFollowTapped: ((Bool) -> Void)?
     var onBlockTapped: ((Bool) -> Void)?
+    var onSortTapped: ((Bool) -> Void)?
     var mid: Int?
 
     override init(frame: CGRect) {
@@ -36,6 +38,7 @@ class UpSpaceTitleSupplementaryView: UICollectionReusableView {
         addSubview(despLabel)
         addSubview(followButton)
         addSubview(blockButton)
+        addSubview(sortButton)
         addLayoutGuide(focusGuide)
 
         imageView.snp.makeConstraints { make in
@@ -54,7 +57,7 @@ class UpSpaceTitleSupplementaryView: UICollectionReusableView {
         despLabel.snp.makeConstraints { make in
             make.leading.equalTo(nameLabel.snp.leading)
             make.top.equalTo(nameLabel.snp.bottom).offset(20)
-            make.trailing.lessThanOrEqualTo(followButton.snp.leading).offset(-40)
+            make.trailing.lessThanOrEqualTo(sortButton.snp.leading).offset(-40)
         }
 
         blockButton.snp.makeConstraints { make in
@@ -68,6 +71,13 @@ class UpSpaceTitleSupplementaryView: UICollectionReusableView {
             make.trailing.equalTo(blockButton.snp.leading).offset(-20)
             make.centerY.equalToSuperview()
             make.width.equalTo(followButton.snp.height).multipliedBy(20.5 / 18.0)
+            make.height.equalTo(80)
+        }
+
+        sortButton.snp.makeConstraints { make in
+            make.trailing.equalTo(followButton.snp.leading).offset(-20)
+            make.centerY.equalToSuperview()
+            make.width.equalTo(sortButton.snp.height).multipliedBy(20.5 / 18.0)
             make.height.equalTo(80)
         }
 
@@ -88,12 +98,24 @@ class UpSpaceTitleSupplementaryView: UICollectionReusableView {
             self?.blockButtonTapped()
         }
 
-        focusGuide.preferredFocusEnvironments = [followButton, blockButton]
+        // isOn = 按播放量排序，off = 按最新发布
+        sortButton.image = UIImage(systemName: "clock")
+        sortButton.onImage = UIImage(systemName: "flame.fill")
+        sortButton.onPrimaryAction = { [weak self] _ in
+            self?.sortButtonTapped()
+        }
+
+        focusGuide.preferredFocusEnvironments = [sortButton, followButton, blockButton]
         focusGuide.snp.makeConstraints { make in
             make.leading.equalToSuperview()
-            make.top.bottom.equalTo(followButton)
-            make.trailing.equalTo(followButton.snp.leading)
+            make.top.bottom.equalTo(sortButton)
+            make.trailing.equalTo(sortButton.snp.leading)
         }
+    }
+
+    @objc private func sortButtonTapped() {
+        sortButton.isOn.toggle()
+        onSortTapped?(sortButton.isOn)
     }
 
     @objc private func followButtonTapped() {

--- a/BilibiliLive/Module/ViewController/UpSpaceViewController.swift
+++ b/BilibiliLive/Module/ViewController/UpSpaceViewController.swift
@@ -14,6 +14,7 @@ class UpSpaceViewController: StandardVideoCollectionViewController<ApiRequest.Up
     var mid: Int!
 
     private var lastAid: Int?
+    private var sortByPlayCount = false
     private var info: WebRequest.UpSpaceInfo?
     private var relation: WebRequest.UpSpaceRelation?
     private let blockedMessageLabel = UILabel()
@@ -37,6 +38,11 @@ class UpSpaceViewController: StandardVideoCollectionViewController<ApiRequest.Up
             headerView.followButton.isHidden = self?.relation?.is_blocked ?? false
             headerView.onBlockTapped = { [weak self, weak headerView] isBlocked in
                 headerView?.followButton.isHidden = isBlocked
+                self?.reloadData()
+            }
+            headerView.sortButton.isOn = self?.sortByPlayCount ?? false
+            headerView.onSortTapped = { [weak self] byPlayCount in
+                self?.sortByPlayCount = byPlayCount
                 self?.reloadData()
             }
         }
@@ -82,7 +88,7 @@ class UpSpaceViewController: StandardVideoCollectionViewController<ApiRequest.Up
             return []
         }
 
-        let res = try await ApiRequest.requestUpSpaceVideo(mid: mid, lastAid: lastAid)
+        let res = try await ApiRequest.requestUpSpaceVideo(mid: mid, lastAid: lastAid, order: sortByPlayCount ? "click" : "pubdate")
         lastAid = res.last?.aid
         return res
     }

--- a/BilibiliLive/Request/ApiRequest.swift
+++ b/BilibiliLive/Request/ApiRequest.swift
@@ -401,12 +401,12 @@ enum ApiRequest {
         }
     }
 
-    static func requestUpSpaceVideo(mid: Int, lastAid: Int?, pageSize: Int = 20) async throws -> [UpSpaceListData] {
+    static func requestUpSpaceVideo(mid: Int, lastAid: Int?, pageSize: Int = 20, order: String = "pubdate") async throws -> [UpSpaceListData] {
         struct Resp: Codable {
             let item: [UpSpaceListData]
         }
 
-        var param: Parameters = ["vmid": mid, "ps": pageSize, "actionKey": "appkey", "disable_rcmd": 0, "fnval": 976, "fnver": 0, "force_host": 0, "fourk": 1, "order": "pubdate", "player_net": 1, "qn": 120]
+        var param: Parameters = ["vmid": mid, "ps": pageSize, "actionKey": "appkey", "disable_rcmd": 0, "fnval": 976, "fnver": 0, "force_host": 0, "fourk": 1, "order": order, "player_net": 1, "qn": 120]
         if let lastAid {
             param["aid"] = lastAid
         }


### PR DESCRIPTION
## 播放流畅度优化

针对播放经常卡顿（明显不如网页端）的问题，增强了 DASH 加载链路的容错：

- **SIDX 多 CDN 重试 + 短超时**：原先只请求 `playableURLs.first`，失败无重试，且走默认 Session（60s 超时），单个慢 CDN 会把起播阻塞很久。现在用独立 Session（6s 请求超时）依次尝试前 3 个 URL。
- **探测即备援**：媒体 playlist 的 `EXT-X-MAP` 与所有 segment 改用 SIDX 实际下载成功的 URL——SIDX 下载本身就是 CDN 可用性探测，首选 CDN 不可用时分段请求自动整体切到备用线路，视频、音频统一受益。
- **修正 PCDN 识别**：#233929b 将 PCDN 判断改为仅看端口后，`szbdyd.com` / `*.mcdn.bilivideo.cn` 这类不带端口的 P2P 节点被漏判、可能排到列表前面。现在端口与域名后缀判断并用。
- **CDN 分级优选**：非 PCDN URL 之间原先按字典序倒排（近似随机）。现在按质量分级：`upos-*.bilivideo.com` 主力节点 > 其他 `bilivideo.com` 边缘节点 > 未知域名 > akam 海外镜像 > PCDN 垫底；同级保持 API 返回顺序（稳定排序）。
- **playlist 响应移出主线程**：resource loader 回调原先 hop 到主线程处理，会被弹幕渲染等负载阻塞。playlist 状态在 `setBilibili`（先于 `setDelegate`）写入后只读，直接在 loader 串行队列处理无竞争。
- **缓冲与预取**：`preferredForwardBufferDuration = 60` 抵抗 CDN 吞吐抖动；`setBilibili` 时并行预取首选视频/音频流的 SIDX（actor 内有 in-progress 去重），缩短起播链路。

不改变现有画质选择行为（仍最高画质起播，杜比/HDR/字幕逻辑未动）。

## UP 主空间按播放量排序

UP 主空间页 header 关注按钮左侧新增排序切换按钮（时钟 = 最新发布，火焰 = 最多播放），切换后重置分页，请求改用 `order=click` 服务端排序（`x/v2/space/archive/cursor` 原生支持该参数）。

## 验证

- `xcodebuild build`（tvOS Simulator）编译通过，无新增警告
- 播放矩阵：1080P / 4K HDR / 带字幕 / 播放中切画质，正常起播
- UP 主空间：切换排序后列表按播放量降序，翻页正常，可切回最新发布

🤖 Generated with [Claude Code](https://claude.com/claude-code)