### PR TITLE
fix: 改善海外网络下高码率播放卡顿

### DIFF
--- a/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
+++ b/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
@@ -47,6 +47,15 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private var aid = 0
     private(set) var httpPort = 0
     private(set) var isHDR = false
+    /// 首选视频流的全部 CDN 候选，按 host 去重，供 CDNDiagnostics 实测
+    private(set) var cdnCandidates = [String]()
+    /// 首选视频流的声明带宽（bps），access log 的 indicatedBitrate 尚未就绪时作健康检测兜底
+    private(set) var primaryVideoBandwidth = 0
+    /// 最近一次生成媒体播放列表时实际选用的分片 host
+    private(set) var currentSegmentHost: String?
+    /// 播放中途检测到当前 host 吞吐撑不住时，外部（BVideoPlayPlugin）指定的优先 host，
+    /// sidx 探测会把它排到候选队首，覆盖默认 URL 顺序
+    private var preferredHost: String?
     deinit {
         httpServer.stop()
     }
@@ -72,6 +81,17 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
 
         """
+    }
+
+    /// DASH manifest 的 bandwidth 是平均码率，而 HLS 的 BANDWIDTH 要求的是分片峰值码率。
+    /// 直接照搬会让 CoreMedia 每拉一个分片都判定 "Segment exceeds specified bandwidth for
+    /// variant" (-12318) 并自行上调内部估计，ABR 从起播起就在用错误的依据决策。
+    ///
+    /// 实测 B 站分片的峰值约为平均的 1.5 倍：785kbps 的流被上调到 1.21Mbps，
+    /// 3.17Mbps 的流被上调到 4.81Mbps。真实平均值仍通过 AVERAGE-BANDWIDTH 如实声明，
+    /// 稳态选流靠它，所以这里的峰值宁可略高。
+    private static func peakBandwidth(forAverage average: Int) -> Int {
+        return Int(Double(average) * 1.5)
     }
 
     private func addVideoPlayBackInfo(info: VideoPlayURLInfo.DashInfo.DashMediaInfo, url: String, duration: Int) {
@@ -118,7 +138,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             supplementCodesc = ",SUPPLEMENTAL-CODECS=\"\(supplementCodesc)\""
         }
         let content = """
-        #EXT-X-STREAM-INF:AUDIO="audio"\(subtitlePlaceHolder),CODECS="\(codecs)"\(supplementCodesc),RESOLUTION=\(info.width ?? 0)x\(info.height ?? 0),FRAME-RATE=\(framerate),BANDWIDTH=\(info.bandwidth),VIDEO-RANGE=\(videoRange)
+        #EXT-X-STREAM-INF:AUDIO="audio"\(subtitlePlaceHolder),CODECS="\(codecs)"\(supplementCodesc),RESOLUTION=\(info.width ?? 0)x\(info.height ?? 0),FRAME-RATE=\(framerate),BANDWIDTH=\(Self.peakBandwidth(forAverage: info.bandwidth)),AVERAGE-BANDWIDTH=\(info.bandwidth),VIDEO-RANGE=\(videoRange)
         \(URLs.customDashPrefix)\(videoInfo.count)?codec=\(info.codecs)&rate=\(info.frame_rate ?? framerate)&width=\(info.width ?? 0)&host=\(URL(string: url)?.host ?? "none")&range=\(info.id)
 
         """
@@ -126,8 +146,30 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         videoInfo.append(PlaybackInfo(info: info, url: url, duration: duration))
     }
 
+    private func collectCDNCandidates(from video: VideoPlayURLInfo.DashInfo.DashMediaInfo?) {
+        guard let video else {
+            cdnCandidates = []
+            primaryVideoBandwidth = 0
+            return
+        }
+        primaryVideoBandwidth = video.bandwidth
+        var seenHosts = Set<String>()
+        cdnCandidates = video.playableURLs.filter { url in
+            guard let host = URLComponents(string: url)?.host else { return false }
+            return seenHosts.insert(host).inserted
+        }
+
+        let detail = cdnCandidates
+            .map { url in
+                let host = URLComponents(string: url)?.host ?? "?"
+                return BVideoUrlUtils.isPCDN(url) ? "  PCDN \(host)" : "  \(host)"
+            }
+            .joined(separator: "\n")
+        Logger.info("cdn candidates for qn \(video.id) (\(video.bandwidth / 1000)kbps):\n\(detail)")
+    }
+
     private func getVideoPlayList(info: PlaybackInfo) async -> String {
-        let sidxResult = await segmentInfoCache.sidx(from: info.info)
+        let sidxResult = await segmentInfoCache.sidx(from: info.info, preferredHost: preferredHost)
         let inits = info.info.segment_base.initialization.components(separatedBy: "-")
         guard let moovIdxStr = inits.last,
               let moovIdx = Int(moovIdxStr),
@@ -136,6 +178,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
               var offset = Int(offsetStr),
               let sidxResult = sidxResult
         else {
+            currentSegmentHost = URLComponents(string: info.url)?.host
             return """
             #EXTM3U
             #EXT-X-VERSION:7
@@ -153,6 +196,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         // 首选 CDN 挂掉时 segment 会整体切到探测成功的备用 URL
         let segment = sidxResult.sidx
         let segmentURL = sidxResult.url
+        currentSegmentHost = URLComponents(string: segmentURL)?.host
         var playList = """
         #EXTM3U
         #EXT-X-VERSION:7
@@ -267,9 +311,10 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         playlists.append(playList)
     }
 
-    func setBilibili(info: VideoPlayURLInfo, subtitles: [SubtitleData], aid: Int, maxQuality: Int? = nil, streamIndex: Int? = nil) {
+    func setBilibili(info: VideoPlayURLInfo, subtitles: [SubtitleData], aid: Int, maxQuality: Int? = nil, streamIndex: Int? = nil, preferredHost: String? = nil) {
         playInfo = info
         self.aid = aid
+        self.preferredHost = preferredHost
         reset()
         hasSubtitle = subtitles.count > 0
         var videos = info.dash.video
@@ -294,6 +339,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             videos = [info.dash.video[streamIndex]]
         } else if let maxQuality = maxQuality {
             // 用户选择了画质，保留该画质的最高码率流
+            // （手动切画质时一般会带 streamIndex，走上面精确选流；这里是无 streamIndex 的兜底）
             let matchingStreams = videos.filter { $0.id == maxQuality }
             if let highestBandwidthStream = matchingStreams.max(by: { $0.bandwidth < $1.bandwidth }) {
                 videos = [highestBandwidthStream]
@@ -326,6 +372,8 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         // 按 bandwidth 降序排序（码率最高的优先，让 AVPlayer 优先选择）
         // 这样可以确保在同一画质等级下，AVPlayer 会选择码率最高的流
         videos.sort { $0.bandwidth > $1.bandwidth }
+
+        collectCDNCandidates(from: videos.first)
 
         // 添加所有 CDN 节点的 URL，让 AVPlayer 自动选择最快的
         // 这样可以解决单个 CDN 节点速度慢的问题
@@ -372,7 +420,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         // i-frame
         if let video = videos.last, let url = video.playableURLs.first {
             let media = """
-            #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=\(video.bandwidth),RESOLUTION=\(video.width!)x\(video.height!),URI="\(URLs.customDashPrefix)\(videoInfo.count)"
+            #EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=\(Self.peakBandwidth(forAverage: video.bandwidth)),RESOLUTION=\(video.width!)x\(video.height!),URI="\(URLs.customDashPrefix)\(videoInfo.count)"
 
             """
             masterPlaylist.append(media)
@@ -382,11 +430,16 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         masterPlaylist.append("\n#EXT-X-ENDLIST\n")
 
         // 预取 AVPlayer 大概率首选流（排序后第一条视频 + 默认音频）的 sidx，
-        // 与 master playlist 加载并行，缩短起播链路；actor 内有 in-progress 去重
-        let prefetchTargets = [videos.first, info.dash.audio?.first].compactMap { $0 }
-        for target in prefetchTargets {
+        // 与 master playlist 加载并行，缩短起播链路；actor 内有 in-progress 去重。
+        // preferredHost 只对视频流生效（音频码率低，host 选择影响不大）
+        if let video = videos.first {
+            Task.detached { [segmentInfoCache, preferredHost] in
+                _ = await segmentInfoCache.sidx(from: video, preferredHost: preferredHost)
+            }
+        }
+        if let audio = info.dash.audio?.first {
             Task.detached { [segmentInfoCache] in
-                _ = await segmentInfoCache.sidx(from: target)
+                _ = await segmentInfoCache.sidx(from: audio)
             }
         }
 
@@ -491,7 +544,7 @@ enum BVideoUrlUtils {
         if let backup {
             urls.append(contentsOf: backup)
         }
-        // 按 tier 优选，同 tier 保持 API 返回顺序（enumerated + offset 实现稳定排序）
+        // 只把 PCDN 垫底；其余保持 API 返回顺序，具体快慢交给动态测速
         return urls.enumerated()
             .sorted { (tier($0.element), $0.offset) < (tier($1.element), $1.offset) }
             .map(\.element)
@@ -511,24 +564,9 @@ enum BVideoUrlUtils {
         return host.hasSuffix("szbdyd.com") || host.hasSuffix("mcdn.bilivideo.cn")
     }
 
-    // CDN 质量分级：upos 主力节点最稳，akam 镜像走海外线路国内慢，PCDN 只作最后备援
-    private static func tier(_ urlString: String) -> Int {
-        if isPCDN(urlString) {
-            return 100
-        }
-        guard let host = URLComponents(string: urlString)?.host?.lowercased() else {
-            return 50
-        }
-        if host.hasPrefix("upos-"), host.hasSuffix(".bilivideo.com") {
-            return host.contains("akam") ? 30 : 0
-        }
-        if host.hasSuffix(".akamaized.net") {
-            return 40
-        }
-        if host.hasSuffix(".bilivideo.com") {
-            return 10
-        }
-        return 20
+    /// 0 = 普通 CDN，1 = PCDN（仅作安全策略垫底，不再做 upos/akam 等静态速度假设）
+    static func tier(_ urlString: String) -> Int {
+        isPCDN(urlString) ? 1 : 0
     }
 
     static func convertVTTFormate(_ time: CGFloat) -> String {
@@ -583,7 +621,7 @@ actor SidxDownloader {
 
     private var cache: [VideoPlayURLInfo.DashInfo.DashMediaInfo: CacheEntry] = [:]
 
-    func sidx(from info: VideoPlayURLInfo.DashInfo.DashMediaInfo) async -> SidxResult? {
+    func sidx(from info: VideoPlayURLInfo.DashInfo.DashMediaInfo, preferredHost: String? = nil) async -> SidxResult? {
         if let cached = cache[info] {
             switch cached {
             case let .ready(sidx):
@@ -596,7 +634,7 @@ actor SidxDownloader {
         }
 
         let task = Task {
-            await downloadSidx(info: info)
+            await downloadSidx(info: info, preferredHost: preferredHost)
         }
 
         cache[info] = .inProgress(task)
@@ -607,9 +645,23 @@ actor SidxDownloader {
         return sidx
     }
 
-    private func downloadSidx(info: VideoPlayURLInfo.DashInfo.DashMediaInfo) async -> SidxResult? {
+    private func elapsedMs(since date: Date) -> Int {
+        Int(Date().timeIntervalSince(date) * 1000)
+    }
+
+    private func downloadSidx(info: VideoPlayURLInfo.DashInfo.DashMediaInfo, preferredHost: String? = nil) async -> SidxResult? {
         let range = info.segment_base.index_range
-        for url in info.playableURLs.prefix(3) {
+        var urls = info.playableURLs
+        // sidx 只有几 KB，探测到的只是延迟不是吞吐；运行时如果发现当前 host 扛不住实际码率，
+        // 由外部指定 preferredHost 时强制优先试这个 host
+        if let preferredHost,
+           let idx = urls.firstIndex(where: { URLComponents(string: $0)?.host == preferredHost })
+        {
+            urls.insert(urls.remove(at: idx), at: 0)
+        }
+        for url in urls.prefix(3) {
+            let host = URLComponents(string: url)?.host ?? url
+            let start = Date()
             if let res = try? await Self.session.request(url,
                                                          headers: ["Range": "bytes=\(range)",
                                                                    "Referer": "https://www.bilibili.com/"])
@@ -617,9 +669,10 @@ actor SidxDownloader {
                 let segment = SidxParseUtil.processIndexData(data: res),
                 !segment.segments.isEmpty
             {
+                Logger.info("sidx ok in \(elapsedMs(since: start))ms from \(host)")
                 return SidxResult(sidx: segment, url: url)
             }
-            Logger.warn("sidx download failed on \(url), try next url")
+            Logger.warn("sidx download failed in \(elapsedMs(since: start))ms on \(host), try next url")
         }
         return nil
     }

--- a/BilibiliLive/Component/Player/CDNDiagnostics.swift
+++ b/BilibiliLive/Component/Player/CDNDiagnostics.swift
@@ -1,0 +1,144 @@
+//
+//  CDNDiagnostics.swift
+//  BilibiliLive
+//
+
+import Alamofire
+import Foundation
+
+/// 主动实测各 CDN 候选节点的吞吐。
+///
+/// 用固定大小的 Range 请求实测各 CDN 候选吞吐。
+/// 静态域名分级已不再承担选速职责（仅 PCDN 垫底），起播 sidx 也只验证连通性。
+enum CDNDiagnostics {
+    struct ProbeResult {
+        let url: String
+        let bytes: Int
+        /// 首字节之后的传输耗时，反映纯下载速度
+        let transferTime: TimeInterval
+        /// DNS + 建连 + TLS + 首字节等待，跨境链路的高 RTT 主要体现在这里
+        let setupTime: TimeInterval
+        let error: String?
+
+        var host: String {
+            URLComponents(string: url)?.host ?? "unknown"
+        }
+
+        var isPCDN: Bool {
+            BVideoUrlUtils.isPCDN(url)
+        }
+
+        var mbps: Double? {
+            guard error == nil, transferTime > 0, bytes > 0 else { return nil }
+            return Double(bytes) * 8 / transferTime / 1_000_000
+        }
+    }
+
+    /// 菜单手动测速 / 运行时切换：较大样本，结果更稳
+    private static let fullProbeBytes = 2 * 1024 * 1024
+    /// 起播择优：小样本，控制在几百毫秒级，不拖慢起播
+    private static let quickProbeBytes = 256 * 1024
+
+    private static let session: Session = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 10
+        config.timeoutIntervalForResource = 15
+        config.headers = HTTPHeaders(["User-Agent": Keys.userAgent])
+        return Session(configuration: config)
+    }()
+
+    private static let quickSession: Session = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 3
+        config.timeoutIntervalForResource = 4
+        config.headers = HTTPHeaders(["User-Agent": Keys.userAgent])
+        return Session(configuration: config)
+    }()
+
+    /// 逐个实测所有候选，返回原始结果供调用方自行判断（如运行时健康检测比较吞吐）。
+    /// 顺序测而非并发：并发会让候选互相抢带宽导致结果失真。
+    static func probeAll(urls: [String]) async -> [ProbeResult] {
+        await probeAll(urls: urls, bytes: fullProbeBytes, session: session)
+    }
+
+    /// 起播用轻量测速，选出实测最快的 host；候选不足或全部失败时返回 nil。
+    static func pickFastestHost(urls: [String]) async -> String? {
+        guard urls.count > 1 else {
+            return urls.first.flatMap { URLComponents(string: $0)?.host }
+        }
+        let results = await probeAll(urls: urls, bytes: quickProbeBytes, session: quickSession)
+        let ranked = results.sorted { ($0.mbps ?? -1) > ($1.mbps ?? -1) }
+        let summary = ranked.map { r in
+            let speed = r.mbps.map { String(format: "%.1fMbps", $0) } ?? "失败"
+            return "\(r.host)=\(speed)"
+        }.joined(separator: ", ")
+        Logger.info("[cdn] 起播轻量测速 (\(quickProbeBytes / 1024)KB): \(summary)")
+        return ranked.first(where: { $0.mbps != nil })?.host
+    }
+
+    /// 测速并把结果写进日志，返回适合直接显示的文本。
+    static func run(urls: [String], currentHost: String?) async -> String {
+        guard !urls.isEmpty else { return "无候选 CDN" }
+        let results = await probeAll(urls: urls)
+        let text = report(results, currentHost: currentHost, probeBytes: fullProbeBytes)
+        Logger.info("\n\(text)")
+        return text
+    }
+
+    private static func probeAll(urls: [String], bytes: Int, session: Session) async -> [ProbeResult] {
+        var results = [ProbeResult]()
+        for url in urls {
+            results.append(await probe(url: url, bytes: bytes, session: session))
+        }
+        return results
+    }
+
+    private static func probe(url: String, bytes: Int, session: Session) async -> ProbeResult {
+        let response = await session.request(url, headers: [
+            "Range": "bytes=0-\(bytes - 1)",
+            "Referer": Keys.referer,
+        ]).serializingData().response
+
+        var setupTime: TimeInterval = 0
+        var transferTime = response.metrics?.taskInterval.duration ?? 0
+        if let metrics = response.metrics?.transactionMetrics.last,
+           let fetchStart = metrics.fetchStartDate,
+           let responseStart = metrics.responseStartDate,
+           let responseEnd = metrics.responseEndDate
+        {
+            setupTime = responseStart.timeIntervalSince(fetchStart)
+            transferTime = responseEnd.timeIntervalSince(responseStart)
+        }
+
+        switch response.result {
+        case let .success(data):
+            return ProbeResult(url: url, bytes: data.count,
+                               transferTime: transferTime, setupTime: setupTime, error: nil)
+        case let .failure(error):
+            return ProbeResult(url: url, bytes: 0,
+                               transferTime: transferTime, setupTime: setupTime,
+                               error: error.localizedDescription)
+        }
+    }
+
+    private static func report(_ results: [ProbeResult], currentHost: String?, probeBytes: Int) -> String {
+        let ranked = results.sorted { ($0.mbps ?? -1) > ($1.mbps ?? -1) }
+        var lines = ["CDN 实测 (\(probeBytes / 1024)KB/节点, 按实测速度排序)"]
+        for (index, result) in ranked.enumerated() {
+            let speed = result.mbps.map { String(format: "%.1f Mbps", $0) } ?? "失败"
+            let setup = String(format: "%.0fms", result.setupTime * 1000)
+            var line = "\(index + 1). \(speed)  setup \(setup)  \(result.host)"
+            if result.isPCDN {
+                line += "  PCDN"
+            }
+            if result.host == currentHost {
+                line += "  <- 正在使用"
+            }
+            if let error = result.error {
+                line += "  (\(error))"
+            }
+            lines.append(line)
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/BilibiliLive/Component/Player/CommonPlayerViewController.swift
+++ b/BilibiliLive/Component/Player/CommonPlayerViewController.swift
@@ -17,6 +17,8 @@ class CommonPlayerViewController: UIViewController {
     private var playToEndObserver: Any?
     private var isEnd = false
     private var isRestoringFromPip = false
+    /// 新 AVPlayerItem ready 后是否自动 play。换 CDN host 等场景可临时关掉，由调用方按用户暂停状态决定是否续播。
+    var autoPlayWhenReady = true
 
     deinit {
         cleanUpPlayerOnExit(force: true)
@@ -164,7 +166,9 @@ extension CommonPlayerViewController {
             case .readyToPlay:
                 isEnd = false
                 activePlugins.forEach { $0.playerWillStart(player: player) }
-                player.play()
+                if autoPlayWhenReady {
+                    player.play()
+                }
             case .failed:
                 activePlugins.forEach { $0.playerDidFail(player: player) }
             default:

--- a/BilibiliLive/Component/Player/Plugins/DebugPlugin.swift
+++ b/BilibiliLive/Component/Player/Plugins/DebugPlugin.swift
@@ -98,7 +98,8 @@ class DebugPlugin: NSObject, CommonPlayerPlugin {
 
         guard let log = player.currentItem?.accessLog() else { return logs }
         guard let item = log.events.last else { return logs }
-        let uri = item.uri ?? ""
+        // 完整 uri 有几百字符，会把浮层其他信息挤掉，只显示 host（完整地址在日志里）
+        let host = URLComponents(string: item.uri ?? "")?.host ?? "-"
         let addr = item.serverAddress ?? ""
         let changes = item.numberOfServerAddressChanges
         let dropped = item.numberOfDroppedVideoFrames
@@ -108,14 +109,14 @@ class DebugPlugin: NSObject, CommonPlayerPlugin {
         let indicatedBitrate = item.indicatedBitrate
         let observedBitrate = item.observedBitrate
         logs += """
-        uri:\(uri), ip:\(addr), change:\(changes)
+        host:\(host), ip:\(addr), change:\(changes)
         drop:\(dropped) stalls:\(stalls)
         bitrate audio:\(bitrateStr(averageAudioBitrate)), video: \(bitrateStr(averageVideoBitrate))
         observedBitrate:\(bitrateStr(observedBitrate))
         indicatedAverageBitrate:\(bitrateStr(indicatedBitrate))
         """
 
-        if let additionDebugInfo = additionDebugInfo?() {
+        if let additionDebugInfo = additionDebugInfo?(), !additionDebugInfo.isEmpty {
             logs = additionDebugInfo + "\n" + logs
         }
         if customInfo.isEmpty == false {

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -6,6 +6,7 @@
 //
 
 import AVKit
+import UIKit
 
 class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     private weak var playerVC: AVPlayerViewController?
@@ -13,10 +14,47 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     private let playData: PlayerDetailData
     private var currentQualityId: Int?
     private var currentPlaybackTime: Double = 0
+    // 记录最近一次实际用于加载的 maxQuality/streamIndex，host 切换时原样复用，
+    // 不去动用户当前的画质模式（自动多档 fallback 还是手动锁定某一档）
+    private var lastMaxQuality: Int?
+    private var lastStreamIndex: Int?
+
+    private var networkLogTimer: Timer?
+    private var lastStalls = 0
+    private var lastDroppedFrames = 0
+    private var cdnProbeReport = ""
+    private var isProbingCDN = false
+
+    // 运行时 CDN 健康检测：只在真实卡顿时换 host，不用 observed/indicated 比特率比
+    // （indicated 常是峰值 BANDWIDTH，播放流畅时 observed 低于它完全正常）
+    private var stallUnhealthyStreak = 0
+    private var isEvaluatingHostSwitch = false
+    private var lastHostSwitchAt: Date?
+    /// 连续几次处于卡顿/等待缓冲才触发，避免单次抖动
+    private let stallTriggerCount = 2
+    /// 换完 host 后的冷静期，避免连续误触发
+    private let hostSwitchCooldown: TimeInterval = 30
+    private let networkLogInterval: TimeInterval = 5
 
     init(detailData: PlayerDetailData) {
         playData = detailData
         currentQualityId = playData.videoPlayURLInfo.quality
+    }
+
+    deinit {
+        networkLogTimer?.invalidate()
+    }
+
+    /// 供 DebugPlugin 浮层显示的网络诊断信息
+    var networkDebugInfo: String {
+        var lines = [String]()
+        if let host = playerDelegate?.currentSegmentHost {
+            lines.append("segment host: \(host)")
+        }
+        if !cdnProbeReport.isEmpty {
+            lines.append(cdnProbeReport)
+        }
+        return lines.joined(separator: "\n")
     }
 
     func playerDidLoad(playerVC: AVPlayerViewController) {
@@ -34,21 +72,285 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         }
     }
 
+    func playerDidStart(player _: AVPlayer) {
+        startNetworkLogging()
+    }
+
+    func playerDidCleanUp(player _: AVPlayer) {
+        stopNetworkLogging()
+    }
+
+    func addMenuItems(current: inout [UIMenuElement]) -> [UIMenuElement] {
+        // 挂进「播放设置」，与 Debug 并列（依赖 SpeedChangerPlugin 先创建 setting 菜单）
+        let action = UIAction(title: isProbingCDN ? "CDN 测速中…" : "CDN 测速",
+                              image: UIImage(systemName: "speedometer"))
+        { [weak self] _ in
+            self?.probeCDN()
+        }
+        if let setting = current.compactMap({ $0 as? UIMenu })
+            .first(where: { $0.identifier == UIMenu.Identifier(rawValue: "setting") }),
+            let index = current.firstIndex(of: setting)
+        {
+            current[index] = setting.replacingChildren(setting.children + [action])
+            return []
+        }
+        return []
+    }
+
+    private func probeCDN() {
+        guard !isProbingCDN else { return }
+        let candidates = playerDelegate?.cdnCandidates ?? []
+        guard !candidates.isEmpty else {
+            cdnProbeReport = "无候选 CDN"
+            return
+        }
+        let currentHost = playerDelegate?.currentSegmentHost
+        isProbingCDN = true
+        cdnProbeReport = "CDN 测速中…"
+        Task { @MainActor [weak self] in
+            let report = await CDNDiagnostics.run(urls: candidates, currentHost: currentHost)
+            self?.cdnProbeReport = report
+            self?.isProbingCDN = false
+        }
+    }
+
+    private func startNetworkLogging() {
+        guard networkLogTimer == nil else { return }
+        networkLogTimer = Timer.scheduledTimer(withTimeInterval: networkLogInterval, repeats: true) { [weak self] _ in
+            self?.logNetworkStatus()
+        }
+    }
+
+    private func stopNetworkLogging() {
+        networkLogTimer?.invalidate()
+        networkLogTimer = nil
+    }
+
+    private func logNetworkStatus() {
+        guard let player = playerVC?.player,
+              let item = player.currentItem,
+              let event = item.accessLog()?.events.last
+        else { return }
+        // event.uri 是内部 variant playlist 的地址（我们用的是自定义 atv://dash/N scheme），
+        // 解析出来的 host 恒为 "dash"，跟实际连的 CDN 无关；真实 host 记录在 playerDelegate 里。
+        let host = playerDelegate?.currentSegmentHost ?? "-"
+        let observedBps = event.observedBitrate
+        let indicatedBps = event.indicatedBitrate
+        let effectiveIndicated = effectiveIndicatedBitrate(from: indicatedBps)
+        let observed = String(format: "%.1f", observedBps / 1_000_000)
+        let indicated = String(format: "%.1f", indicatedBps / 1_000_000)
+        let effective = String(format: "%.1f", effectiveIndicated / 1_000_000)
+        let stalls = event.numberOfStalls
+        let dropped = event.numberOfDroppedVideoFrames
+        let tcs = player.timeControlStatus
+        let waiting = player.reasonForWaitingToPlay?.rawValue ?? "-"
+        let keepUp = item.isPlaybackLikelyToKeepUp
+        let buffered = bufferedSeconds(of: item)
+        let stallDelta = stalls - lastStalls
+        Logger.info("playback host \(host) observed \(observed)Mbps indicated \(indicated)Mbps effective \(effective)Mbps stalls \(stalls)(+\(stallDelta)) dropped \(dropped)(+\(dropped - lastDroppedFrames)) serverChanges \(event.numberOfServerAddressChanges) tcs \(tcs.rawValue) wait \(waiting) keepUp \(keepUp) buffered \(String(format: "%.1f", buffered))s")
+        lastStalls = stalls
+        lastDroppedFrames = dropped
+
+        checkStallHealth(stallDelta: stallDelta, buffered: buffered, currentHost: host)
+    }
+
+    /// 用户明确暂停（.paused）。卡缓冲/断网时是 .waitingToPlayAtSpecifiedRate，仍应做健康检测。
+    private var isUserPaused: Bool {
+        playerVC?.player?.timeControlStatus == .paused
+    }
+
+    private var isWaitingToPlay: Bool {
+        playerVC?.player?.timeControlStatus == .waitingToPlayAtSpecifiedRate
+    }
+
+    /// access log 的 indicated 在起播/loading 时常为 0 或负值；日志里的 effective 用流声明平均带宽兜底。
+    private func effectiveIndicatedBitrate(from accessLogIndicated: Double) -> Double {
+        if accessLogIndicated > 0 { return accessLogIndicated }
+        guard let declared = playerDelegate?.primaryVideoBandwidth, declared > 0 else { return 0 }
+        return Double(declared)
+    }
+
+    private func bufferedSeconds(of item: AVPlayerItem) -> Double {
+        guard let range = item.loadedTimeRanges.first?.timeRangeValue else { return 0 }
+        let end = range.start.seconds + range.duration.seconds
+        let current = item.currentTime().seconds
+        guard end.isFinite, current.isFinite else { return 0 }
+        return max(0, end - current)
+    }
+
+    /// 只根据真实卡顿触发换源：正在 waiting，或本周期新增了 stall。
+    /// 播放流畅时仅 observed < indicated 不触发——indicated 常是峰值，低一些完全正常。
+    private func checkStallHealth(stallDelta: Int, buffered: Double, currentHost: String) {
+        guard !isUserPaused, !isEvaluatingHostSwitch else {
+            stallUnhealthyStreak = 0
+            return
+        }
+        if let lastSwitch = lastHostSwitchAt, Date().timeIntervalSince(lastSwitch) < hostSwitchCooldown {
+            return
+        }
+
+        let unhealthy = isWaitingToPlay || stallDelta > 0
+        if unhealthy {
+            stallUnhealthyStreak += 1
+        } else {
+            stallUnhealthyStreak = 0
+            return
+        }
+        guard stallUnhealthyStreak >= stallTriggerCount else { return }
+        stallUnhealthyStreak = 0
+
+        let requiredMbps = Double(playerDelegate?.primaryVideoBandwidth ?? 0) / 1_000_000
+        Logger.info("[cdn] 检测到卡顿 (waiting=\(isWaitingToPlay), stallDelta=\(stallDelta), buffered \(String(format: "%.1f", buffered))s)，重新测速")
+        Task { @MainActor [weak self] in
+            await self?.evaluateHostSwitch(currentHost: currentHost, requiredMbps: requiredMbps)
+        }
+    }
+
+    @MainActor
+    private func evaluateHostSwitch(currentHost: String, requiredMbps: Double) async {
+        guard !isEvaluatingHostSwitch else { return }
+        guard !isUserPaused else { return }
+        let candidates = playerDelegate?.cdnCandidates ?? []
+        guard candidates.count > 1 else { return }
+        isEvaluatingHostSwitch = true
+        defer { isEvaluatingHostSwitch = false }
+
+        Logger.info("[cdn] \(currentHost) 因卡顿重新测速 \(candidates.count) 个候选")
+        let results = await CDNDiagnostics.probeAll(urls: candidates)
+        // 测速是异步的，期间用户可能已手动暂停；换源会重建 AVPlayer，必须取消
+        guard !isUserPaused else {
+            Logger.info("[cdn] 用户已暂停，取消 host 切换")
+            return
+        }
+        guard let best = results.filter({ $0.mbps != nil }).max(by: { $0.mbps! < $1.mbps! }),
+              let bestMbps = best.mbps
+        else {
+            Logger.info("[cdn] 候选测速全部失败，保持 \(currentHost)")
+            return
+        }
+        guard best.host != currentHost else {
+            Logger.info("[cdn] 最快仍是当前 \(currentHost) (\(String(format: "%.1f", bestMbps))Mbps)，不切换")
+            return
+        }
+        // 和当前 host 的实测比，而不是和峰值 indicated 比（短测速几乎总能超过声明码率）
+        if let currentMbps = results.first(where: { $0.host == currentHost })?.mbps {
+            guard bestMbps > currentMbps * 1.3 else {
+                Logger.info("[cdn] 最快候选 \(best.host) (\(String(format: "%.1f", bestMbps))Mbps) 未明显快于当前 \(currentHost) (\(String(format: "%.1f", currentMbps))Mbps)，保持")
+                return
+            }
+        } else if requiredMbps > 0, bestMbps < requiredMbps {
+            Logger.info("[cdn] 最快候选 \(best.host) (\(String(format: "%.1f", bestMbps))Mbps) 低于流平均码率需求，保持 \(currentHost)")
+            return
+        }
+        lastHostSwitchAt = Date()
+        Logger.info("[cdn] 切换 host: \(currentHost) -> \(best.host) (实测\(String(format: "%.1f", bestMbps))Mbps)")
+        await switchHost(to: best.host)
+    }
+
+    @MainActor
+    private func switchHost(to host: String) async {
+        guard let player = playerVC?.player else { return }
+        // 必须在换源前记下播放意图：新 AVPlayer 默认就是 .paused，换源后再读 isUserPaused 会误判成用户暂停
+        let shouldResume = !isUserPaused
+        guard shouldResume else {
+            Logger.info("[cdn] 用户已暂停，取消 host 切换")
+            return
+        }
+        let currentTime = player.currentTime().seconds
+        guard currentTime > 0 else { return }
+        currentPlaybackTime = currentTime
+
+        // 关掉 readyToPlay 自动 play，改由下面按 shouldResume 显式 play；异步恢复默认，避开尚未送达的 status KVO
+        let commonVC = playerVC?.parent as? CommonPlayerViewController
+        commonVC?.autoPlayWhenReady = false
+        defer {
+            DispatchQueue.main.async {
+                commonVC?.autoPlayWhenReady = true
+            }
+        }
+
+        do {
+            try await playmedia(urlInfo: playData.videoPlayURLInfo, playerInfo: playData.playerInfo, maxQuality: lastMaxQuality, streamIndex: lastStreamIndex, preferredHost: host, isQualitySwitch: true)
+            if let newPlayer = playerVC?.player {
+                await newPlayer.seek(to: CMTime(seconds: currentPlaybackTime, preferredTimescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
+                if shouldResume {
+                    newPlayer.play()
+                } else {
+                    newPlayer.pause()
+                }
+            }
+        } catch {
+            Logger.warn("[cdn] 切换 host 失败: \(error)")
+        }
+    }
+
     func playerDidDismiss(playerVC: AVPlayerViewController) {
         guard let currentTime = playerVC.player?.currentTime().seconds, currentTime > 0 else { return }
         WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime), epid: playData.epid, seasonId: playData.seasonId, subType: playData.subType)
     }
 
+    /// 与资源加载器选主视频流的逻辑对齐，取出该流各 CDN host 的代表 URL，供起播轻量测速。
+    private func primaryCDNCandidates(from info: VideoPlayURLInfo, maxQuality: Int?, streamIndex: Int?) -> [String] {
+        var videos = info.dash.video
+        if Settings.preferAvc {
+            let videosMap = Dictionary(grouping: videos, by: { $0.id })
+            for (key, values) in videosMap {
+                if values.contains(where: { !$0.isHevc }) {
+                    videos.removeAll(where: { $0.id == key && $0.isHevc })
+                }
+            }
+        }
+        if let streamIndex, streamIndex < info.dash.video.count {
+            videos = [info.dash.video[streamIndex]]
+        } else if let maxQuality {
+            let matching = videos.filter { $0.id == maxQuality }
+            if let best = matching.max(by: { $0.bandwidth < $1.bandwidth }) {
+                videos = [best]
+            } else {
+                videos = matching
+            }
+        } else {
+            let qualityLimit = Settings.mediaQuality.qn
+            videos = videos.filter { $0.id <= qualityLimit }
+            if let highest = videos.map(\.id).max() {
+                videos = videos.filter { $0.id == highest }
+            }
+        }
+        videos.sort { $0.bandwidth > $1.bandwidth }
+        guard let primary = videos.first else { return [] }
+        var seenHosts = Set<String>()
+        return primary.playableURLs.filter { url in
+            guard let host = URLComponents(string: url)?.host else { return false }
+            return seenHosts.insert(host).inserted
+        }
+    }
+
     @MainActor
-    private func playmedia(urlInfo: VideoPlayURLInfo, playerInfo: PlayerInfo?, maxQuality: Int? = nil, streamIndex: Int? = nil, isQualitySwitch: Bool = false) async throws {
+    private func playmedia(urlInfo: VideoPlayURLInfo, playerInfo: PlayerInfo?, maxQuality: Int? = nil, streamIndex: Int? = nil, preferredHost: String? = nil, isQualitySwitch: Bool = false) async throws {
         let playURL = URL(string: BilibiliVideoResourceLoaderDelegate.URLs.play)!
         let headers: [String: String] = [
             "User-Agent": Keys.userAgent,
             "Referer": Keys.referer(for: playData.aid),
         ]
         let asset = AVURLAsset(url: playURL, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
+        // access log 是按 item 统计的，换流后累计值归零，这里同步重置增量基准
+        lastStalls = 0
+        lastDroppedFrames = 0
+        lastMaxQuality = maxQuality
+        lastStreamIndex = streamIndex
+
+        // 起播 / 切画质时做一次轻量测速选 host；运行时已指定 preferredHost 的切换则跳过
+        var resolvedHost = preferredHost
+        if resolvedHost == nil {
+            let candidates = primaryCDNCandidates(from: urlInfo, maxQuality: maxQuality, streamIndex: streamIndex)
+            if let best = await CDNDiagnostics.pickFastestHost(urls: candidates) {
+                resolvedHost = best
+                Logger.info("[cdn] 起播选用 host: \(best)")
+            }
+        }
+
         playerDelegate = BilibiliVideoResourceLoaderDelegate()
-        playerDelegate?.setBilibili(info: urlInfo, subtitles: playerInfo?.subtitle?.subtitles ?? [], aid: playData.aid, maxQuality: maxQuality, streamIndex: streamIndex)
+        playerDelegate?.setBilibili(info: urlInfo, subtitles: playerInfo?.subtitle?.subtitles ?? [], aid: playData.aid, maxQuality: maxQuality, streamIndex: streamIndex, preferredHost: resolvedHost)
 
         // 只在初次加载时设置 appliesPreferredDisplayCriteriaAutomatically，切换画质时跳过
         if !isQualitySwitch {
@@ -100,8 +402,11 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         // 0 表示无限制，让 AVPlayer 根据网络条件自动选择最高可用码率
         playerItem.preferredPeakBitRate = 0
 
-        // 前向缓冲 60s，扛住 CDN 吞吐抖动减少卡顿（4K HDR ~25Mbps × 60s ≈ 190MB，可接受）
-        playerItem.preferredForwardBufferDuration = 60
+        // 之前设成 60s 是为了扛 CDN 吞吐抖动，但 BANDWIDTH 声明错误的根因已修复，
+        // 实测 CDN 吞吐充裕，不再需要这么激进的预缓冲。60s 在连续快进时的副作用是：
+        // 每次 seek 都会立刻为新位置起一大批 60s 的 range 请求，下一个 seek 一来又整体取消重来，
+        // 密集 seek 下网络连接层疲于开连接/取消，表现为长时间无响应。降到 15s 大幅减少这种抖动。
+        playerItem.preferredForwardBufferDuration = 15
 
         let player = AVPlayer(playerItem: playerItem)
         playerVC?.player = nil

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -222,29 +222,40 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
             Logger.info("[cdn] 用户已暂停，取消 host 切换")
             return
         }
-        guard let best = results.filter({ $0.mbps != nil }).max(by: { $0.mbps! < $1.mbps! }),
-              let bestMbps = best.mbps
-        else {
+        let ranked = results.filter { $0.mbps != nil }.sorted { ($0.mbps ?? -1) > ($1.mbps ?? -1) }
+        guard !ranked.isEmpty else {
             Logger.info("[cdn] 候选测速全部失败，保持 \(currentHost)")
             return
         }
-        guard best.host != currentHost else {
-            Logger.info("[cdn] 最快仍是当前 \(currentHost) (\(String(format: "%.1f", bestMbps))Mbps)，不切换")
+
+        // 优先更快的非当前节点；若短测速仍显示当前最快，则取第二名做强制尝试
+        let alternate = ranked.first(where: { $0.host != currentHost })
+        guard let target = alternate, let targetMbps = target.mbps else {
+            Logger.info("[cdn] 没有其他可用候选，保持 \(currentHost)")
             return
         }
-        // 和当前 host 的实测比，而不是和峰值 indicated 比（短测速几乎总能超过声明码率）
-        if let currentMbps = results.first(where: { $0.host == currentHost })?.mbps {
-            guard bestMbps > currentMbps * 1.3 else {
-                Logger.info("[cdn] 最快候选 \(best.host) (\(String(format: "%.1f", bestMbps))Mbps) 未明显快于当前 \(currentHost) (\(String(format: "%.1f", currentMbps))Mbps)，保持")
-                return
-            }
-        } else if requiredMbps > 0, bestMbps < requiredMbps {
-            Logger.info("[cdn] 最快候选 \(best.host) (\(String(format: "%.1f", bestMbps))Mbps) 低于流平均码率需求，保持 \(currentHost)")
+        if requiredMbps > 0, targetMbps < requiredMbps * 0.5 {
+            Logger.info("[cdn] 备选 \(target.host) (\(String(format: "%.1f", targetMbps))Mbps) 远低于流码率，放弃切换")
             return
         }
+
+        let currentMbps = ranked.first(where: { $0.host == currentHost })?.mbps
+        let reason: String
+        if let currentMbps, targetMbps > currentMbps * 1.3 {
+            reason = "测速明显更快"
+        } else if let currentMbps, targetMbps >= currentMbps * 0.7 {
+            // 短测速乐观且接近时，当前节点已真实卡顿，强制换一个试试
+            reason = "测速接近但已卡顿，强制尝试"
+        } else if currentMbps == nil {
+            reason = "当前节点测速失败"
+        } else {
+            Logger.info("[cdn] 备选 \(target.host) (\(String(format: "%.1f", targetMbps))Mbps) 明显慢于当前 \(currentHost) (\(String(format: "%.1f", currentMbps!))Mbps)，保持")
+            return
+        }
+
         lastHostSwitchAt = Date()
-        Logger.info("[cdn] 切换 host: \(currentHost) -> \(best.host) (实测\(String(format: "%.1f", bestMbps))Mbps)")
-        await switchHost(to: best.host)
+        Logger.info("[cdn] 切换 host: \(currentHost) -> \(target.host) (实测\(String(format: "%.1f", targetMbps))Mbps, \(reason))")
+        await switchHost(to: target.host)
     }
 
     @MainActor

--- a/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
@@ -136,6 +136,9 @@ class VideoPlayerViewModel {
         let danmu = DanmuViewPlugin(provider: danmuProvider)
         let upnp = BUpnpPlugin(duration: data.detail?.View.duration)
         let debug = DebugPlugin()
+        debug.additionDebugInfo = { [weak playplugin] in
+            playplugin?.networkDebugInfo ?? ""
+        }
         let playSpeed = SpeedChangerPlugin()
         playSpeed.$currentPlaySpeed.sink { [weak danmu] speed in
             danmu?.danMuView.playingSpeed = speed.value
@@ -158,7 +161,8 @@ class VideoPlayerViewModel {
             }
         }
 
-        var plugins: [CommonPlayerPlugin] = [playplugin, danmu, playSpeed, upnp, debug, playlist, qualitySelector]
+        // playSpeed 先创建 identifier=setting 的「播放设置」菜单，后续插件（CDN 测速、Debug 等）才能挂进去
+        var plugins: [CommonPlayerPlugin] = [playSpeed, playplugin, danmu, upnp, debug, playlist, qualitySelector]
 
         if let clips = data.clips {
             let clip = BVideoClipsPlugin(clipInfos: clips)


### PR DESCRIPTION
## Summary
- 修正 HLS `BANDWIDTH` 低估（DASH 平均码率被当成峰值），避免 CoreMedia `-12318` 干扰 ABR；同时声明 `AVERAGE-BANDWIDTH`
- 起播对候选 CDN 做轻量测速并择优；播放中仅在真实卡顿（`waitingToPlay` / stall 增加）时重新测速换 host，避免把「observed < 峰值 indicated」误判成需要换源
- 卡顿后若备选测速接近或短测速仍显示当前最快，强制尝试其他可用 host（短测速偏乐观）
- 换 host 前记录播放意图，避免新 `AVPlayer` 默认 paused 导致切完不续播；换源时可临时关闭 `readyToPlay` 自动 play
- 静态域名分级只保留 PCDN 垫底；前向缓冲 60s → 15s；「CDN 测速」放入播放设置（Debug 旁）

## Test plan
- [x] 海外/跨境网络下开播 4K/高码率，日志有起播轻量测速并选用较快 host
- [x] 播放流畅但 observed 低于峰值 indicated 时，不会误触发换源
- [x] 真实卡顿（waiting / stall）后才会测速；若有明显更快节点则切换并续播
- [x] 连续卡顿且测速接近时，会强制尝试其他 host（日志含「测速接近但已卡顿，强制尝试」）
- [x] 手动暂停后不会被 CDN 切换自动拉起续播
- [x] 播放设置中可见「CDN 测速」；连续快进/后退不再长时间无响应
- [ ] 国内网络回归：普通画质起播与切画质正常