### PR TITLE
重构：抽取可复用的沉浸式播放基础能力

### DIFF
--- a/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
+++ b/BilibiliLive/Component/Player/BilibiliVideoResourceLoaderDelegate.swift
@@ -37,7 +37,11 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private var playlists = [String]()
     private var subtitles = [String: String]()
     private var videoInfo = [PlaybackInfo]()
-    private var segmentInfoCache = SidxDownloader()
+    // Keep SIDX selection scoped to this playback session. A shared cache can
+    // leak the CDN chosen for one player into another concurrent player (for
+    // example, picture-in-picture) because preferredHost is not part of the
+    // media-info cache key.
+    private let segmentInfoCache = SidxDownloader(maxEntries: 16)
     private var hasAudioInMasterListAdded = false
     private var audioRenditionIndex = 0
     private(set) var playInfo: VideoPlayURLInfo?
@@ -57,6 +61,7 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     /// sidx 探测会把它排到候选队首，覆盖默认 URL 顺序
     private var preferredHost: String?
     deinit {
+        cancelPendingIndexLoads()
         httpServer.stop()
     }
 
@@ -429,21 +434,19 @@ class BilibiliVideoResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
         masterPlaylist.append("\n#EXT-X-ENDLIST\n")
 
-        // 预取 AVPlayer 大概率首选流（排序后第一条视频 + 默认音频）的 sidx，
-        // 与 master playlist 加载并行，缩短起播链路；actor 内有 in-progress 去重。
-        // preferredHost 只对视频流生效（音频码率低，host 选择影响不大）
-        if let video = videos.first {
-            Task.detached { [segmentInfoCache, preferredHost] in
-                _ = await segmentInfoCache.sidx(from: video, preferredHost: preferredHost)
-            }
-        }
-        if let audio = info.dash.audio?.first {
-            Task.detached { [segmentInfoCache] in
-                _ = await segmentInfoCache.sidx(from: audio)
-            }
-        }
-
         Logger.debug("masterPlaylist: \(masterPlaylist)")
+    }
+
+    func prewarmPrimaryVideoIndex() async {
+        guard let firstVideo = videoInfo.first else { return }
+        _ = await segmentInfoCache.sidx(from: firstVideo.info, preferredHost: preferredHost)
+    }
+
+    func cancelPendingIndexLoads() {
+        let cache = segmentInfoCache
+        Task {
+            await cache.cancelAll()
+        }
     }
 
     private func reportError(_ loadingRequest: AVAssetResourceLoadingRequest, withErrorCode error: Int) {
@@ -606,8 +609,8 @@ actor SidxDownloader {
     }
 
     private enum CacheEntry {
-        case inProgress(Task<SidxResult?, Never>)
-        case ready(SidxResult?)
+        case inProgress(token: UUID, task: Task<SidxResult?, Never>)
+        case ready(SidxResult)
     }
 
     // sidx 只有几 KB，用短超时的独立 Session，避免默认 60s 超时把起播卡死
@@ -619,34 +622,80 @@ actor SidxDownloader {
         return Session(configuration: config)
     }()
 
+    private let maxEntries: Int
     private var cache: [VideoPlayURLInfo.DashInfo.DashMediaInfo: CacheEntry] = [:]
+    private var accessOrder: [VideoPlayURLInfo.DashInfo.DashMediaInfo] = []
+
+    init(maxEntries: Int = 16) {
+        self.maxEntries = maxEntries
+    }
 
     func sidx(from info: VideoPlayURLInfo.DashInfo.DashMediaInfo, preferredHost: String? = nil) async -> SidxResult? {
         if let cached = cache[info] {
+            touch(info)
             switch cached {
             case let .ready(sidx):
                 Logger.debug("sidx cache hit \(info.id)")
                 return sidx
-            case let .inProgress(sidx):
+            case let .inProgress(_, task):
                 Logger.debug("sidx cache wait \(info.id)")
-                return await sidx.value
+                return await task.value
             }
         }
 
-        let task = Task {
-            await downloadSidx(info: info, preferredHost: preferredHost)
+        let token = UUID()
+        let task = Task<SidxResult?, Never> {
+            guard !Task.isCancelled else { return nil }
+            return await downloadSidx(info: info, preferredHost: preferredHost)
         }
 
-        cache[info] = .inProgress(task)
+        cache[info] = .inProgress(token: token, task: task)
+        touch(info)
 
         let sidx = await task.value
-        cache[info] = .ready(sidx)
+        guard case let .inProgress(currentToken, _) = cache[info],
+              currentToken == token
+        else {
+            return nil
+        }
+        if let sidx {
+            cache[info] = .ready(sidx)
+        } else {
+            cache[info] = nil
+            accessOrder.removeAll { $0 == info }
+        }
+        trimToCapacity()
         Logger.debug("get sidx \(info.id)")
         return sidx
     }
 
+    func cancelAll() {
+        for entry in cache.values {
+            if case let .inProgress(_, task) = entry {
+                task.cancel()
+            }
+        }
+        cache.removeAll()
+        accessOrder.removeAll()
+    }
+
     private func elapsedMs(since date: Date) -> Int {
         Int(Date().timeIntervalSince(date) * 1000)
+    }
+
+    private func touch(_ info: VideoPlayURLInfo.DashInfo.DashMediaInfo) {
+        accessOrder.removeAll { $0 == info }
+        accessOrder.append(info)
+    }
+
+    private func trimToCapacity() {
+        while cache.count > maxEntries, let oldest = accessOrder.first {
+            accessOrder.removeFirst()
+            if case let .inProgress(_, task) = cache[oldest] {
+                task.cancel()
+            }
+            cache[oldest] = nil
+        }
     }
 
     private func downloadSidx(info: VideoPlayURLInfo.DashInfo.DashMediaInfo, preferredHost: String? = nil) async -> SidxResult? {
@@ -660,12 +709,14 @@ actor SidxDownloader {
             urls.insert(urls.remove(at: idx), at: 0)
         }
         for url in urls.prefix(3) {
+            guard !Task.isCancelled else { return nil }
             let host = URLComponents(string: url)?.host ?? url
             let start = Date()
             if let res = try? await Self.session.request(url,
                                                          headers: ["Range": "bytes=\(range)",
                                                                    "Referer": "https://www.bilibili.com/"])
                 .serializingData().result.get(),
+                !Task.isCancelled,
                 let segment = SidxParseUtil.processIndexData(data: res),
                 !segment.segments.isEmpty
             {

--- a/BilibiliLive/Component/Player/CommonPlayerViewController.swift
+++ b/BilibiliLive/Component/Player/CommonPlayerViewController.swift
@@ -15,10 +15,13 @@ class CommonPlayerViewController: UIViewController {
     private var rateObserver: NSKeyValueObservation?
     private var statusObserver: NSKeyValueObservation?
     private var playToEndObserver: Any?
+    private var playbackStalledObserver: Any?
     private var isEnd = false
     private var isRestoringFromPip = false
     /// 新 AVPlayerItem ready 后是否自动 play。换 CDN host 等场景可临时关掉，由调用方按用户暂停状态决定是否续播。
     var autoPlayWhenReady = true
+    var showsPlaybackControls = true
+    var allowsPictureInPicturePlayback = true
 
     deinit {
         cleanUpPlayerOnExit(force: true)
@@ -30,7 +33,8 @@ class CommonPlayerViewController: UIViewController {
         view.addSubview(playerVC.view)
         playerVC.didMove(toParent: self)
         playerVC.view.snp.makeConstraints { $0.edges.equalToSuperview() }
-        playerVC.allowsPictureInPicturePlayback = true
+        playerVC.showsPlaybackControls = showsPlaybackControls
+        playerVC.allowsPictureInPicturePlayback = allowsPictureInPicturePlayback
         playerVC.delegate = self
 
         let playerObservation = playerVC.observe(\.player, options: [.old, .new]) { [weak self] vc, obs in
@@ -67,13 +71,17 @@ class CommonPlayerViewController: UIViewController {
     }
 
     func removePlugin(plugin: CommonPlayerPlugin) {
+        let removingPlugins = activePlugins.filter { $0 == plugin }
+        removingPlugins.forEach { $0.playerWillCleanUp(playerVC: playerVC) }
         if let player = playerVC.player {
-            activePlugins.filter { $0 == plugin }.forEach { $0.playerDidCleanUp(player: player) }
+            removingPlugins.forEach { $0.playerDidCleanUp(player: player) }
         }
         activePlugins.removeAll { $0 == plugin }
     }
 
     func removeAllPlugins() {
+        guard !activePlugins.isEmpty else { return }
+        activePlugins.forEach { $0.playerWillCleanUp(playerVC: playerVC) }
         if let player = playerVC.player {
             Logger.debug("removeAllPlugins: clean up player: \(player)")
             activePlugins.forEach { $0.playerDidCleanUp(player: player) }
@@ -81,7 +89,11 @@ class CommonPlayerViewController: UIViewController {
         activePlugins.removeAll()
     }
 
+    func playerWillStart(player: AVPlayer) {}
+    func playerDidStart(player: AVPlayer) {}
     func playerDidEnd(player: AVPlayer) {}
+    func playerDidStall(player: AVPlayer) {}
+    func playerDidFail(player: AVPlayer) {}
 
     func showErrorAlertAndExit(title: String = "播放失败", message: String = "未知错误") {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
@@ -102,6 +114,20 @@ class CommonPlayerViewController: UIViewController {
         playerVC.transportBarCustomMenuItems = menus
     }
 
+    func stopPlayback() {
+        cleanUpPlayerOnExit(force: true)
+    }
+
+    func currentPlaybackTimeInSeconds() -> Int? {
+        guard let seconds = playerVC.player?.currentTime().seconds,
+              seconds.isFinite,
+              seconds > 0
+        else {
+            return nil
+        }
+        return Int(seconds.rounded(.down))
+    }
+
     private func cleanUpPlayerOnExit(force: Bool = false) {
         let isPictureInPictureRunning = PipRecorder.shared.playingPipViewController.contains { $0.playerVC == playerVC }
         let shouldCleanUp = force || ((isBeingDismissed || isMovingFromParent || navigationController?.isBeingDismissed == true) && !isPictureInPictureRunning)
@@ -109,14 +135,13 @@ class CommonPlayerViewController: UIViewController {
 
         cleanUpObserver()
 
-        if let player = playerVC.player {
-            player.pause()
-            removeAllPlugins()
-            player.replaceCurrentItem(with: nil)
-            playerVC.player = nil
-        } else {
-            activePlugins.removeAll()
-        }
+        let player = playerVC.player
+        player?.pause()
+        // Plugins may still be preparing the first AVPlayer. Always run their
+        // cleanup hook even when playerVC.player has not been installed yet.
+        removeAllPlugins()
+        player?.replaceCurrentItem(with: nil)
+        playerVC.player = nil
     }
 
     private func cleanUpObserver() {
@@ -126,6 +151,10 @@ class CommonPlayerViewController: UIViewController {
             NotificationCenter.default.removeObserver(playToEndObserver)
         }
         playToEndObserver = nil
+        if let playbackStalledObserver {
+            NotificationCenter.default.removeObserver(playbackStalledObserver)
+        }
+        playbackStalledObserver = nil
     }
 }
 
@@ -151,6 +180,7 @@ extension CommonPlayerViewController {
     private func playerRateDidChange(player: AVPlayer) {
         if player.rate > 0 {
             activePlugins.forEach { $0.playerDidStart(player: player) }
+            playerDidStart(player: player)
         } else if player.rate == 0 {
             if !isEnd {
                 activePlugins.forEach { $0.playerDidPause(player: player) }
@@ -166,11 +196,13 @@ extension CommonPlayerViewController {
             case .readyToPlay:
                 isEnd = false
                 activePlugins.forEach { $0.playerWillStart(player: player) }
+                playerWillStart(player: player)
                 if autoPlayWhenReady {
                     player.play()
                 }
             case .failed:
                 activePlugins.forEach { $0.playerDidFail(player: player) }
+                playerDidFail(player: player)
             default:
                 break
             }
@@ -183,6 +215,14 @@ extension CommonPlayerViewController {
             isEnd = true
             activePlugins.forEach { $0.playerDidEnd(player: player) }
             playerDidEnd(player: player)
+        }
+        if let playbackStalledObserver {
+            NotificationCenter.default.removeObserver(playbackStalledObserver)
+        }
+        playbackStalledObserver = NotificationCenter.default.addObserver(forName: .AVPlayerItemPlaybackStalled, object: playerItem, queue: .main) { [weak self] _ in
+            guard let self, let player = playerVC.player else { return }
+            activePlugins.forEach { $0.playerDidStall(player: player) }
+            playerDidStall(player: player)
         }
     }
 }

--- a/BilibiliLive/Component/Player/Plugins/CommonPlayerPlugin.swift
+++ b/BilibiliLive/Component/Player/Plugins/CommonPlayerPlugin.swift
@@ -14,6 +14,7 @@ protocol CommonPlayerPlugin: NSObject {
 
     func playerDidLoad(playerVC: AVPlayerViewController)
     func playerDidDismiss(playerVC: AVPlayerViewController)
+    func playerWillCleanUp(playerVC: AVPlayerViewController)
     func playerDidChange(player: AVPlayer)
     func playerItemDidChange(playerItem: AVPlayerItem)
 
@@ -21,6 +22,7 @@ protocol CommonPlayerPlugin: NSObject {
     func playerDidStart(player: AVPlayer)
     func playerDidPause(player: AVPlayer)
     func playerDidEnd(player: AVPlayer)
+    func playerDidStall(player: AVPlayer)
     func playerDidFail(player: AVPlayer)
     func playerDidCleanUp(player: AVPlayer)
 }
@@ -33,11 +35,13 @@ extension CommonPlayerPlugin {
     func playerDidStart(player: AVPlayer) {}
     func playerDidPause(player: AVPlayer) {}
     func playerDidEnd(player: AVPlayer) {}
+    func playerDidStall(player: AVPlayer) {}
     func playerDidFail(player: AVPlayer) {}
     func playerDidCleanUp(player: AVPlayer) {}
 
     func playerDidLoad(playerVC: AVPlayerViewController) {}
     func playerDidDismiss(playerVC: AVPlayerViewController) {}
+    func playerWillCleanUp(playerVC: AVPlayerViewController) {}
     func playerDidChange(player: AVPlayer) {}
     func playerItemDidChange(playerItem: AVPlayerItem) {}
 }

--- a/BilibiliLive/Component/Video/PlayContextCache.swift
+++ b/BilibiliLive/Component/Video/PlayContextCache.swift
@@ -1,0 +1,177 @@
+//
+//  PlayContextCache.swift
+//  BilibiliLive
+//
+//  Created by OpenAI on 2026/4/4.
+//
+
+import Foundation
+
+struct PlayContextKey: Hashable {
+    let aid: Int
+    let cid: Int
+    let epid: Int
+    let seasonId: Int
+}
+
+struct PlayContextSnapshot {
+    let cid: Int
+    let playerInfo: PlayerInfo?
+    let videoPlayURLInfo: VideoPlayURLInfo
+    var detail: VideoDetail?
+}
+
+enum PlayContextMode: String, Hashable {
+    case preview
+    case regular
+
+    var includeDetail: Bool {
+        switch self {
+        case .preview:
+            return false
+        case .regular:
+            return true
+        }
+    }
+
+    var requestOptions: PlayURLRequestOptions {
+        switch self {
+        case .preview:
+            return .featuredPreview
+        case .regular:
+            return .regular
+        }
+    }
+}
+
+private struct PlayContextEntryKey: Hashable {
+    let contextKey: PlayContextKey
+    let mode: PlayContextMode
+}
+
+actor PlayContextCache {
+    private struct InFlightEntry {
+        let token: UUID
+        let task: Task<PlayContextSnapshot, Error>
+    }
+
+    private let maxEntries = 12
+    private let recentEntriesToKeep = 4
+    private var entries = [PlayContextEntryKey: PlayContextSnapshot]()
+    private var inFlightTasks = [PlayContextEntryKey: InFlightEntry]()
+    private var accessOrder = [PlayContextEntryKey]()
+
+    func preload(playInfo: PlayInfo, mode: PlayContextMode) async {
+        _ = try? await context(for: playInfo, mode: mode)
+    }
+
+    func context(for playInfo: PlayInfo, mode: PlayContextMode) async throws -> PlayContextSnapshot {
+        let resolvedPlayInfo = try await resolvePlayInfo(playInfo)
+        let entryKey = PlayContextEntryKey(contextKey: resolvedPlayInfo.contextKey, mode: mode)
+
+        if var cached = entries[entryKey] {
+            touch(entryKey)
+            if mode.includeDetail, cached.detail == nil {
+                cached.detail = try? await WebRequest.requestDetailVideo(aid: resolvedPlayInfo.aid)
+                entries[entryKey] = cached
+            }
+            return cached
+        }
+
+        if let entry = inFlightTasks[entryKey] {
+            var snapshot = try await entry.task.value
+            touch(entryKey)
+            if mode.includeDetail, snapshot.detail == nil {
+                snapshot.detail = try? await WebRequest.requestDetailVideo(aid: resolvedPlayInfo.aid)
+                entries[entryKey] = snapshot
+            }
+            return snapshot
+        }
+
+        let token = UUID()
+        let task = Task<PlayContextSnapshot, Error> {
+            try Task.checkCancellation()
+            async let playerInfoReq = try? WebRequest.requestPlayerInfo(aid: resolvedPlayInfo.aid, cid: resolvedPlayInfo.cid ?? 0)
+            async let detailReq = mode.includeDetail ? (try? WebRequest.requestDetailVideo(aid: resolvedPlayInfo.aid)) : nil
+
+            let playURLInfo: VideoPlayURLInfo
+            if resolvedPlayInfo.isBangumi {
+                playURLInfo = try await WebRequest.requestPcgPlayUrl(aid: resolvedPlayInfo.aid,
+                                                                     cid: resolvedPlayInfo.cid ?? 0,
+                                                                     options: mode.requestOptions)
+            } else {
+                playURLInfo = try await WebRequest.requestPlayUrl(aid: resolvedPlayInfo.aid,
+                                                                  cid: resolvedPlayInfo.cid ?? 0,
+                                                                  options: mode.requestOptions)
+            }
+            try Task.checkCancellation()
+
+            return PlayContextSnapshot(cid: resolvedPlayInfo.cid ?? 0,
+                                       playerInfo: await playerInfoReq,
+                                       videoPlayURLInfo: playURLInfo,
+                                       detail: await detailReq)
+        }
+
+        let entry = InFlightEntry(token: token, task: task)
+        inFlightTasks[entryKey] = entry
+        return try await resolve(entry, for: entryKey)
+    }
+
+    func trim(keeping playInfos: [PlayInfo]) {
+        let baseKeysToKeep = Set(playInfos.compactMap { info -> PlayContextKey? in
+            guard let cid = info.cid, cid > 0 else { return nil }
+            return PlayContextKey(aid: info.aid,
+                                  cid: cid,
+                                  epid: info.epid ?? 0,
+                                  seasonId: info.seasonId ?? 0)
+        })
+        let recentKeys = Array(accessOrder.reversed().prefix(recentEntriesToKeep))
+        let entryKeysToKeep = Set((Array(entries.keys) + Array(inFlightTasks.keys)).filter {
+            baseKeysToKeep.contains($0.contextKey)
+        } + recentKeys)
+        for key in inFlightTasks.keys.filter({ !entryKeysToKeep.contains($0) }) {
+            inFlightTasks[key]?.task.cancel()
+            inFlightTasks[key] = nil
+        }
+        entries = entries.filter { entryKeysToKeep.contains($0.key) }
+        accessOrder.removeAll { !entryKeysToKeep.contains($0) }
+    }
+
+    private func resolve(_ entry: InFlightEntry, for key: PlayContextEntryKey) async throws -> PlayContextSnapshot {
+        do {
+            let snapshot = try await entry.task.value
+            guard inFlightTasks[key]?.token == entry.token else {
+                throw CancellationError()
+            }
+            inFlightTasks[key] = nil
+            entries[key] = snapshot
+            touch(key)
+            trimToMaxEntryCount()
+            return snapshot
+        } catch {
+            if inFlightTasks[key]?.token == entry.token {
+                inFlightTasks[key] = nil
+            }
+            throw error
+        }
+    }
+
+    private func touch(_ key: PlayContextEntryKey) {
+        accessOrder.removeAll { $0 == key }
+        accessOrder.append(key)
+    }
+
+    private func trimToMaxEntryCount() {
+        guard entries.count > maxEntries else { return }
+        var removableKeys = accessOrder
+        while entries.count > maxEntries, let key = removableKeys.first {
+            removableKeys.removeFirst()
+            accessOrder.removeAll { $0 == key }
+            entries[key] = nil
+        }
+    }
+
+    private func resolvePlayInfo(_ playInfo: PlayInfo) async throws -> PlayInfo {
+        try await PlayInfoResolver.resolve(playInfo)
+    }
+}

--- a/BilibiliLive/Component/Video/PlayContextCache.swift
+++ b/BilibiliLive/Component/Video/PlayContextCache.swift
@@ -66,7 +66,7 @@ actor PlayContextCache {
     }
 
     func context(for playInfo: PlayInfo, mode: PlayContextMode) async throws -> PlayContextSnapshot {
-        let resolvedPlayInfo = try await resolvePlayInfo(playInfo)
+        let resolvedPlayInfo = try await PlayInfoResolver.resolve(playInfo)
         let entryKey = PlayContextEntryKey(contextKey: resolvedPlayInfo.contextKey, mode: mode)
 
         if var cached = entries[entryKey] {
@@ -169,9 +169,5 @@ actor PlayContextCache {
             accessOrder.removeAll { $0 == key }
             entries[key] = nil
         }
-    }
-
-    private func resolvePlayInfo(_ playInfo: PlayInfo) async throws -> PlayInfo {
-        try await PlayInfoResolver.resolve(playInfo)
     }
 }

--- a/BilibiliLive/Component/Video/PlayInfoResolver.swift
+++ b/BilibiliLive/Component/Video/PlayInfoResolver.swift
@@ -1,0 +1,67 @@
+//
+//  PlayInfoResolver.swift
+//  BilibiliLive
+//
+//  Created by OpenAI on 2026/4/6.
+//
+
+import Foundation
+
+enum PlayInfoResolver {
+    static func resolve(_ playInfo: PlayInfo) async throws -> PlayInfo {
+        if playInfo.isBangumi {
+            return try await resolveBangumi(playInfo)
+        }
+        guard !playInfo.isCidVaild else { return playInfo }
+        guard playInfo.aid > 0 else {
+            throw ValidationError.argumentInvalid(message: "缺少视频 aid，无法解析播放信息")
+        }
+        var resolved = playInfo
+        resolved.cid = try await WebRequest.requestCid(aid: playInfo.aid)
+        return resolved
+    }
+
+    private static func resolveBangumi(_ playInfo: PlayInfo) async throws -> PlayInfo {
+        var resolved = playInfo
+        let info: BangumiInfo
+        if let epid = playInfo.epid, epid > 0 {
+            info = try await WebRequest.requestBangumiInfo(epid: epid)
+        } else if let seasonId = playInfo.seasonId, seasonId > 0 {
+            info = try await WebRequest.requestBangumiInfo(seasonID: seasonId)
+        } else if playInfo.aid > 0 {
+            if !playInfo.isCidVaild {
+                resolved.cid = try await WebRequest.requestCid(aid: playInfo.aid)
+            }
+            return resolved
+        } else {
+            throw ValidationError.argumentInvalid(message: "缺少番剧标识，无法解析播放信息")
+        }
+
+        resolved.seasonId = info.season_id
+        resolved.subType = resolved.subType ?? info.type
+
+        let matchedEpisode: BangumiInfo.Episode?
+        if let epid = resolved.epid, epid > 0 {
+            matchedEpisode = info.episodes.first(where: { $0.id == epid }) ?? info.episodes.first
+        } else {
+            matchedEpisode = info.episodes.first
+        }
+
+        if let episode = matchedEpisode {
+            resolved.epid = episode.id
+            resolved.aid = episode.aid
+            resolved.cid = episode.cid
+            if resolved.coverURL == nil {
+                resolved.coverURL = episode.cover
+            }
+            if resolved.title?.isEmpty != false {
+                let combinedTitle = [episode.title, episode.long_title]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " ")
+                resolved.title = combinedTitle.isEmpty ? resolved.title : combinedTitle
+            }
+        }
+
+        return resolved
+    }
+}

--- a/BilibiliLive/Component/Video/PlayerMediaWarmup.swift
+++ b/BilibiliLive/Component/Video/PlayerMediaWarmup.swift
@@ -67,6 +67,7 @@ actor PlayerMediaWarmupManager {
     private var prepared = [String: PreparedPlayerMedia]()
     private var inFlight = [String: InFlightEntry]()
     private var accessOrder = [String]()
+    private var cancellationGeneration = 0
 
     init(playContextCache: PlayContextCache) {
         self.playContextCache = playContextCache
@@ -77,7 +78,10 @@ actor PlayerMediaWarmupManager {
     }
 
     func preparedMedia(for playInfo: PlayInfo) async throws -> PreparedPlayerMedia {
+        let generation = cancellationGeneration
         let resolvedPlayInfo = try await PlayInfoResolver.resolve(playInfo)
+        try Task.checkCancellation()
+        guard cancellationGeneration == generation else { throw CancellationError() }
         let key = resolvedPlayInfo.sequenceKey
         if let cached = prepared[key] {
             touch(key)
@@ -128,6 +132,7 @@ actor PlayerMediaWarmupManager {
     }
 
     func cancelAll() {
+        cancellationGeneration += 1
         inFlight.values.forEach { $0.task.cancel() }
         inFlight.removeAll()
         prepared.removeAll()

--- a/BilibiliLive/Component/Video/PlayerMediaWarmup.swift
+++ b/BilibiliLive/Component/Video/PlayerMediaWarmup.swift
@@ -1,0 +1,157 @@
+//
+//  PlayerMediaWarmup.swift
+//  BilibiliLive
+//
+//  Created by OpenAI on 2026/4/4.
+//
+
+import AVFoundation
+import Foundation
+
+final class PreparedPlayerMedia: @unchecked Sendable {
+    let asset: AVURLAsset
+    let delegate: BilibiliVideoResourceLoaderDelegate
+
+    init(asset: AVURLAsset, delegate: BilibiliVideoResourceLoaderDelegate) {
+        self.asset = asset
+        self.delegate = delegate
+    }
+}
+
+enum PlayerMediaFactory {
+    static func prepare(aid: Int,
+                        urlInfo: VideoPlayURLInfo,
+                        playerInfo: PlayerInfo?,
+                        maxQuality: Int? = nil,
+                        streamIndex: Int? = nil,
+                        preferredHost: String? = nil) async throws -> PreparedPlayerMedia
+    {
+        let playURL = URL(string: BilibiliVideoResourceLoaderDelegate.URLs.play)!
+        let headers: [String: String] = [
+            "User-Agent": Keys.userAgent,
+            "Referer": Keys.referer(for: aid),
+        ]
+        let asset = AVURLAsset(url: playURL, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
+        let delegate = BilibiliVideoResourceLoaderDelegate()
+        delegate.setBilibili(info: urlInfo,
+                             subtitles: playerInfo?.subtitle?.subtitles ?? [],
+                             aid: aid,
+                             maxQuality: maxQuality,
+                             streamIndex: streamIndex,
+                             preferredHost: preferredHost)
+        asset.resourceLoader.setDelegate(delegate, queue: DispatchQueue(label: "loader.\(aid).\(UUID().uuidString)"))
+        try Task.checkCancellation()
+        let playable = try await asset.load(.isPlayable)
+        try Task.checkCancellation()
+        guard playable else {
+            throw "加载资源失败"
+        }
+        try await withTaskCancellationHandler {
+            await delegate.prewarmPrimaryVideoIndex()
+            try Task.checkCancellation()
+        } onCancel: {
+            delegate.cancelPendingIndexLoads()
+        }
+        return PreparedPlayerMedia(asset: asset, delegate: delegate)
+    }
+}
+
+actor PlayerMediaWarmupManager {
+    private struct InFlightEntry {
+        let token: UUID
+        let task: Task<PreparedPlayerMedia, Error>
+    }
+
+    private let maxPreparedEntries = 4
+    private let playContextCache: PlayContextCache
+    private var prepared = [String: PreparedPlayerMedia]()
+    private var inFlight = [String: InFlightEntry]()
+    private var accessOrder = [String]()
+
+    init(playContextCache: PlayContextCache) {
+        self.playContextCache = playContextCache
+    }
+
+    func preload(playInfo: PlayInfo) async {
+        _ = try? await preparedMedia(for: playInfo)
+    }
+
+    func preparedMedia(for playInfo: PlayInfo) async throws -> PreparedPlayerMedia {
+        let key = playInfo.sequenceKey
+        if let cached = prepared[key] {
+            touch(key)
+            return cached
+        }
+        if let entry = inFlight[key] {
+            return try await resolve(entry, for: key)
+        }
+
+        let token = UUID()
+        let task = Task<PreparedPlayerMedia, Error> {
+            try Task.checkCancellation()
+            let snapshot = try await playContextCache.context(for: playInfo, mode: .regular)
+            try Task.checkCancellation()
+            return try await PlayerMediaFactory.prepare(
+                aid: playInfo.aid,
+                urlInfo: snapshot.videoPlayURLInfo,
+                playerInfo: snapshot.playerInfo
+            )
+        }
+
+        let entry = InFlightEntry(token: token, task: task)
+        inFlight[key] = entry
+        return try await resolve(entry, for: key)
+    }
+
+    private func resolve(_ entry: InFlightEntry, for key: String) async throws -> PreparedPlayerMedia {
+        do {
+            let media = try await entry.task.value
+            if let cached = prepared[key] {
+                touch(key)
+                return cached
+            }
+            guard inFlight[key]?.token == entry.token else {
+                throw CancellationError()
+            }
+            inFlight[key] = nil
+            prepared[key] = media
+            touch(key)
+            trimToCapacity()
+            return media
+        } catch {
+            if inFlight[key]?.token == entry.token {
+                inFlight[key] = nil
+            }
+            throw error
+        }
+    }
+
+    func retain(playInfos: [PlayInfo]) {
+        let allowedKeys = Set(playInfos.map(\.sequenceKey))
+        for (key, entry) in inFlight where !allowedKeys.contains(key) {
+            entry.task.cancel()
+            inFlight[key] = nil
+        }
+        prepared = prepared.filter { allowedKeys.contains($0.key) }
+        accessOrder.removeAll { !allowedKeys.contains($0) }
+    }
+
+    func cancelAll() {
+        inFlight.values.forEach { $0.task.cancel() }
+        inFlight.removeAll()
+        prepared.removeAll()
+        accessOrder.removeAll()
+    }
+
+    private func touch(_ key: String) {
+        accessOrder.removeAll { $0 == key }
+        accessOrder.append(key)
+    }
+
+    private func trimToCapacity() {
+        while prepared.count > maxPreparedEntries, let key = accessOrder.first {
+            accessOrder.removeFirst()
+            prepared[key] = nil
+        }
+    }
+}

--- a/BilibiliLive/Component/Video/PlayerMediaWarmup.swift
+++ b/BilibiliLive/Component/Video/PlayerMediaWarmup.swift
@@ -77,7 +77,8 @@ actor PlayerMediaWarmupManager {
     }
 
     func preparedMedia(for playInfo: PlayInfo) async throws -> PreparedPlayerMedia {
-        let key = playInfo.sequenceKey
+        let resolvedPlayInfo = try await PlayInfoResolver.resolve(playInfo)
+        let key = resolvedPlayInfo.sequenceKey
         if let cached = prepared[key] {
             touch(key)
             return cached
@@ -89,10 +90,10 @@ actor PlayerMediaWarmupManager {
         let token = UUID()
         let task = Task<PreparedPlayerMedia, Error> {
             try Task.checkCancellation()
-            let snapshot = try await playContextCache.context(for: playInfo, mode: .regular)
+            let snapshot = try await playContextCache.context(for: resolvedPlayInfo, mode: .regular)
             try Task.checkCancellation()
             return try await PlayerMediaFactory.prepare(
-                aid: playInfo.aid,
+                aid: resolvedPlayInfo.aid,
                 urlInfo: snapshot.videoPlayURLInfo,
                 playerInfo: snapshot.playerInfo
             )
@@ -124,16 +125,6 @@ actor PlayerMediaWarmupManager {
             }
             throw error
         }
-    }
-
-    func retain(playInfos: [PlayInfo]) {
-        let allowedKeys = Set(playInfos.map(\.sequenceKey))
-        for (key, entry) in inFlight where !allowedKeys.contains(key) {
-            entry.task.cancel()
-            inFlight[key] = nil
-        }
-        prepared = prepared.filter { allowedKeys.contains($0.key) }
-        accessOrder.removeAll { !allowedKeys.contains($0) }
     }
 
     func cancelAll() {

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -9,6 +9,8 @@ import AVKit
 import UIKit
 
 class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
+    var onLoadFailure: ((String) -> Void)?
+
     private weak var playerVC: AVPlayerViewController?
     private var playerDelegate: BilibiliVideoResourceLoaderDelegate?
     private let playInfo: PlayInfo
@@ -372,7 +374,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
                            isQualitySwitch: Bool = false)
     {
         let generation = beginLoadGeneration()
-        loadTask = Task { [weak self] in
+        loadTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 try await self.playmedia(urlInfo: urlInfo,
@@ -385,6 +387,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
                 return
             } catch {
                 Logger.warn("[player] Failed to prepare media: \(error)")
+                self.onLoadFailure?(error.localizedDescription)
             }
         }
     }

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -386,6 +386,10 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
             } catch is CancellationError {
                 return
             } catch {
+                guard !Task.isCancelled,
+                      self.loadGeneration == generation,
+                      self.playerVC != nil
+                else { return }
                 Logger.warn("[player] Failed to prepare media: \(error)")
                 self.onLoadFailure?(error.localizedDescription)
             }

--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -11,7 +11,12 @@ import UIKit
 class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     private weak var playerVC: AVPlayerViewController?
     private var playerDelegate: BilibiliVideoResourceLoaderDelegate?
+    private let playInfo: PlayInfo
     private let playData: PlayerDetailData
+    private let reportWatchHistory: Bool
+    private let minimizeStalling: Bool
+    private let isMuted: Bool
+    private let mediaWarmupManager: PlayerMediaWarmupManager?
     private var currentQualityId: Int?
     private var currentPlaybackTime: Double = 0
     // 记录最近一次实际用于加载的 maxQuality/streamIndex，host 切换时原样复用，
@@ -35,9 +40,22 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     /// 换完 host 后的冷静期，避免连续误触发
     private let hostSwitchCooldown: TimeInterval = 30
     private let networkLogInterval: TimeInterval = 5
+    private var loadTask: Task<Void, Never>?
+    private var loadGeneration = 0
 
-    init(detailData: PlayerDetailData) {
+    init(playInfo: PlayInfo,
+         detailData: PlayerDetailData,
+         reportWatchHistory: Bool = true,
+         minimizeStalling: Bool = true,
+         isMuted: Bool = false,
+         mediaWarmupManager: PlayerMediaWarmupManager? = nil)
+    {
+        self.playInfo = playInfo
         playData = detailData
+        self.reportWatchHistory = reportWatchHistory
+        self.minimizeStalling = minimizeStalling
+        self.isMuted = isMuted
+        self.mediaWarmupManager = mediaWarmupManager
         currentQualityId = playData.videoPlayURLInfo.quality
     }
 
@@ -60,10 +78,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     func playerDidLoad(playerVC: AVPlayerViewController) {
         self.playerVC = playerVC
         playerVC.player = nil
-        playerVC.appliesPreferredDisplayCriteriaAutomatically = Settings.contentMatch
-        Task {
-            try? await playmedia(urlInfo: playData.videoPlayURLInfo, playerInfo: playData.playerInfo)
-        }
+        startLoad(urlInfo: playData.videoPlayURLInfo, playerInfo: playData.playerInfo)
     }
 
     func playerWillStart(player: AVPlayer) {
@@ -76,8 +91,10 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         startNetworkLogging()
     }
 
-    func playerDidCleanUp(player _: AVPlayer) {
+    func playerDidCleanUp(player: AVPlayer) {
         stopNetworkLogging()
+        player.pause()
+        player.replaceCurrentItem(with: nil)
     }
 
     func addMenuItems(current: inout [UIMenuElement]) -> [UIMenuElement] {
@@ -281,7 +298,14 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         }
 
         do {
-            try await playmedia(urlInfo: playData.videoPlayURLInfo, playerInfo: playData.playerInfo, maxQuality: lastMaxQuality, streamIndex: lastStreamIndex, preferredHost: host, isQualitySwitch: true)
+            let generation = beginLoadGeneration()
+            try await playmedia(urlInfo: playData.videoPlayURLInfo,
+                                playerInfo: playData.playerInfo,
+                                generation: generation,
+                                maxQuality: lastMaxQuality,
+                                streamIndex: lastStreamIndex,
+                                preferredHost: host,
+                                isQualitySwitch: true)
             if let newPlayer = playerVC?.player {
                 await newPlayer.seek(to: CMTime(seconds: currentPlaybackTime, preferredTimescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
                 if shouldResume {
@@ -296,6 +320,7 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     }
 
     func playerDidDismiss(playerVC: AVPlayerViewController) {
+        guard reportWatchHistory else { return }
         guard let currentTime = playerVC.player?.currentTime().seconds, currentTime > 0 else { return }
         WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime), epid: playData.epid, seasonId: playData.seasonId, subType: playData.subType)
     }
@@ -336,21 +361,112 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         }
     }
 
+    func playerWillCleanUp(playerVC: AVPlayerViewController) {
+        invalidatePendingLoad(tearingDown: true)
+    }
+
+    private func startLoad(urlInfo: VideoPlayURLInfo,
+                           playerInfo: PlayerInfo?,
+                           maxQuality: Int? = nil,
+                           streamIndex: Int? = nil,
+                           isQualitySwitch: Bool = false)
+    {
+        let generation = beginLoadGeneration()
+        loadTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.playmedia(urlInfo: urlInfo,
+                                         playerInfo: playerInfo,
+                                         generation: generation,
+                                         maxQuality: maxQuality,
+                                         streamIndex: streamIndex,
+                                         isQualitySwitch: isQualitySwitch)
+            } catch is CancellationError {
+                return
+            } catch {
+                Logger.warn("[player] Failed to prepare media: \(error)")
+            }
+        }
+    }
+
+    private func beginLoadGeneration() -> Int {
+        loadTask?.cancel()
+        loadTask = nil
+        loadGeneration += 1
+        return loadGeneration
+    }
+
+    private func invalidatePendingLoad(tearingDown: Bool) {
+        loadTask?.cancel()
+        loadTask = nil
+        loadGeneration += 1
+        playerDelegate = nil
+        if tearingDown {
+            playerVC = nil
+        }
+    }
+
+    private func ensureActiveLoad(_ generation: Int) throws -> AVPlayerViewController {
+        guard !Task.isCancelled,
+              loadGeneration == generation,
+              let playerVC
+        else {
+            throw CancellationError()
+        }
+        return playerVC
+    }
+
     @MainActor
-    private func playmedia(urlInfo: VideoPlayURLInfo, playerInfo: PlayerInfo?, maxQuality: Int? = nil, streamIndex: Int? = nil, preferredHost: String? = nil, isQualitySwitch: Bool = false) async throws {
-        let playURL = URL(string: BilibiliVideoResourceLoaderDelegate.URLs.play)!
-        let headers: [String: String] = [
-            "User-Agent": Keys.userAgent,
-            "Referer": Keys.referer(for: playData.aid),
-        ]
-        let asset = AVURLAsset(url: playURL, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
-        // access log 是按 item 统计的，换流后累计值归零，这里同步重置增量基准
+    private func playmedia(urlInfo: VideoPlayURLInfo,
+                           playerInfo: PlayerInfo?,
+                           generation: Int,
+                           maxQuality: Int? = nil,
+                           streamIndex: Int? = nil,
+                           preferredHost: String? = nil,
+                           isQualitySwitch: Bool = false) async throws
+    {
+        _ = try ensureActiveLoad(generation)
+        let prepared = try await preparedMedia(urlInfo: urlInfo,
+                                               playerInfo: playerInfo,
+                                               maxQuality: maxQuality,
+                                               streamIndex: streamIndex,
+                                               preferredHost: preferredHost,
+                                               isQualitySwitch: isQualitySwitch)
+        // The await above may finish after a newer load generation. Validate
+        // before retaining its resource-loader delegate or touching the player.
+        let playerVC = try ensureActiveLoad(generation)
+        let delegate = prepared.delegate
+        let asset = prepared.asset
+        playerDelegate = delegate
+
+        // AVKit 不允许在同一场全屏播放里反复切换该属性，因此只在首次装配资源时计算一次。
+        if !isQualitySwitch {
+            playerVC.appliesPreferredDisplayCriteriaAutomatically = shouldApplyContentMatch(delegate: delegate)
+        }
+
+        await prepare(toPlay: asset, generation: generation)
+    }
+
+    private func preparedMedia(urlInfo: VideoPlayURLInfo,
+                               playerInfo: PlayerInfo?,
+                               maxQuality: Int?,
+                               streamIndex: Int?,
+                               preferredHost: String?,
+                               isQualitySwitch: Bool) async throws -> PreparedPlayerMedia
+    {
+        if !isQualitySwitch,
+           maxQuality == nil,
+           streamIndex == nil,
+           preferredHost == nil,
+           let mediaWarmupManager
+        {
+            return try await mediaWarmupManager.preparedMedia(for: playInfo)
+        }
         lastStalls = 0
         lastDroppedFrames = 0
         lastMaxQuality = maxQuality
         lastStreamIndex = streamIndex
 
-        // 起播 / 切画质时做一次轻量测速选 host；运行时已指定 preferredHost 的切换则跳过
         var resolvedHost = preferredHost
         if resolvedHost == nil {
             let candidates = primaryCDNCandidates(from: urlInfo, maxQuality: maxQuality, streamIndex: streamIndex)
@@ -360,24 +476,12 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
             }
         }
 
-        playerDelegate = BilibiliVideoResourceLoaderDelegate()
-        playerDelegate?.setBilibili(info: urlInfo, subtitles: playerInfo?.subtitle?.subtitles ?? [], aid: playData.aid, maxQuality: maxQuality, streamIndex: streamIndex, preferredHost: resolvedHost)
-
-        // 只在初次加载时设置 appliesPreferredDisplayCriteriaAutomatically，切换画质时跳过
-        if !isQualitySwitch {
-            if Settings.contentMatchOnlyInHDR {
-                if playerDelegate?.isHDR != true {
-                    playerVC?.appliesPreferredDisplayCriteriaAutomatically = false
-                }
-            }
-        }
-
-        asset.resourceLoader.setDelegate(playerDelegate, queue: DispatchQueue(label: "loader"))
-        let playable = try await asset.load(.isPlayable)
-        if !playable {
-            throw "加载资源失败"
-        }
-        await prepare(toPlay: asset)
+        return try await PlayerMediaFactory.prepare(aid: playData.aid,
+                                                    urlInfo: urlInfo,
+                                                    playerInfo: playerInfo,
+                                                    maxQuality: maxQuality,
+                                                    streamIndex: streamIndex,
+                                                    preferredHost: resolvedHost)
     }
 
     @MainActor
@@ -393,20 +497,42 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
 
         // 重新加载视频，使用新的画质
         do {
-            try await playmedia(urlInfo: playData.videoPlayURLInfo, playerInfo: playData.playerInfo, maxQuality: qualityId, streamIndex: streamIndex, isQualitySwitch: true)
+            let generation = beginLoadGeneration()
+            try await playmedia(urlInfo: playData.videoPlayURLInfo,
+                                playerInfo: playData.playerInfo,
+                                generation: generation,
+                                maxQuality: qualityId,
+                                streamIndex: streamIndex,
+                                isQualitySwitch: true)
 
             // 恢复播放位置并继续播放
-            if let newPlayer = playerVC?.player {
-                await newPlayer.seek(to: CMTime(seconds: currentPlaybackTime, preferredTimescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
-                newPlayer.play()
-            }
+            guard loadGeneration == generation,
+                  !Task.isCancelled,
+                  playerVC != nil,
+                  let newPlayer = playerVC?.player
+            else { return }
+            await newPlayer.seek(to: CMTime(seconds: currentPlaybackTime, preferredTimescale: 1), toleranceBefore: .zero, toleranceAfter: .zero)
+            guard loadGeneration == generation, !Task.isCancelled else { return }
+            newPlayer.play()
+        } catch is CancellationError {
+            return
         } catch {
             Logger.warn("[quality] Failed to switch quality: \(error)")
         }
     }
 
+    private func shouldApplyContentMatch(delegate: BilibiliVideoResourceLoaderDelegate) -> Bool {
+        guard Settings.contentMatch else { return false }
+        guard Settings.contentMatchOnlyInHDR else { return true }
+        return delegate.isHDR == true
+    }
+
     @MainActor
-    func prepare(toPlay asset: AVURLAsset) async {
+    func prepare(toPlay asset: AVURLAsset, generation: Int) async {
+        guard loadGeneration == generation,
+              !Task.isCancelled,
+              let playerVC
+        else { return }
         let playerItem = AVPlayerItem(asset: asset)
 
         // 设置 preferredPeakBitRate 为一个很高的值，让 AVPlayer 优先选择高码率流
@@ -420,7 +546,19 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         playerItem.preferredForwardBufferDuration = 15
 
         let player = AVPlayer(playerItem: playerItem)
-        playerVC?.player = nil
-        playerVC?.player = player
+        player.automaticallyWaitsToMinimizeStalling = minimizeStalling
+        player.isMuted = isMuted
+        guard loadGeneration == generation, !Task.isCancelled else {
+            player.pause()
+            player.replaceCurrentItem(with: nil)
+            return
+        }
+        playerVC.player = nil
+        guard loadGeneration == generation, !Task.isCancelled else {
+            player.pause()
+            player.replaceCurrentItem(with: nil)
+            return
+        }
+        playerVC.player = player
     }
 }

--- a/BilibiliLive/Component/Video/Plugins/VideoPlayListPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/VideoPlayListPlugin.swift
@@ -8,15 +8,18 @@
 import AVKit
 
 class VideoPlayListPlugin: NSObject, CommonPlayerPlugin {
-    private let playNextActionIdentifierPrefix = "play.next"
+    private let previousActionIdentifierPrefix = "play.previous"
+    private let nextActionIdentifierPrefix = "play.next"
     private weak var playerVC: AVPlayerViewController?
     var onPlayEnd: (() -> Void)?
+    var onPlayPreviousWithInfo: ((PlayInfo) -> Void)?
     var onPlayNextWithInfo: ((PlayInfo) -> Void)?
+    var onShowCurrentDetail: ((PlayInfo) -> Void)?
 
-    let nextProvider: VideoNextProvider?
+    let sequenceProvider: VideoSequenceProvider?
 
-    init(nextProvider: VideoNextProvider?) {
-        self.nextProvider = nextProvider
+    init(sequenceProvider: VideoSequenceProvider?) {
+        self.sequenceProvider = sequenceProvider
     }
 
     func playerDidLoad(playerVC: AVPlayerViewController) {
@@ -24,25 +27,30 @@ class VideoPlayListPlugin: NSObject, CommonPlayerPlugin {
     }
 
     func playerWillStart(player: AVPlayer) {
-        guard let playerVC, let nextProvider, nextProvider.count > 1 else { return }
-
-        // 仅当最后一项是我们之前添加的 "next" action 时才移除，避免误删其他自定义 action
-        if let last = playerVC.infoViewActions.last,
-           last.identifier.rawValue.hasPrefix(playNextActionIdentifierPrefix)
-        {
-            playerVC.infoViewActions.removeLast()
+        guard let playerVC, let sequenceProvider else { return }
+        let menuState = MainActor.assumeIsolated { () -> (PlayInfo?, PlayInfo?) in
+            guard sequenceProvider.count > 0 else { return (nil, nil) }
+            return (sequenceProvider.peekPrevious(), sequenceProvider.peekNext())
+        }
+        let next = menuState.1
+        var actions = playerVC.infoViewActions.filter {
+            !$0.identifier.rawValue.hasPrefix(nextActionIdentifierPrefix)
         }
 
-        if let next = nextProvider.peekNext() {
-            let title = next.title ?? "下一集"
+        if let next {
+            let title = actionTitle(prefix: "下一条", playInfo: next)
             let nextAction = UIAction(title: title,
                                       image: UIImage(systemName: "forward.end.fill"),
-                                      identifier: .init(rawValue: "\(playNextActionIdentifierPrefix).\(next.aid).\(next.cid ?? 0)"))
+                                      identifier: .init(rawValue: "\(nextActionIdentifierPrefix).\(next.sequenceKey)"))
             { [weak self] _ in
-                _ = self?.playNext()
+                Task { [weak self] in
+                    _ = await self?.playNext()
+                }
             }
-            playerVC.infoViewActions.append(nextAction)
+            actions.append(nextAction)
         }
+
+        playerVC.infoViewActions = actions
     }
 
     func addMenuItems(current: inout [UIMenuElement]) -> [UIMenuElement] {
@@ -52,36 +60,74 @@ class VideoPlayListPlugin: NSObject, CommonPlayerPlugin {
             action.state = (action.state == .off) ? .on : .off
             Settings.loopPlay = action.state == .on
         }
+        var actions = [UIMenuElement](arrayLiteral: loopAction)
+        let currentInfo = sequenceProvider.map { provider in
+            MainActor.assumeIsolated { provider.current() }
+        } ?? nil
+        if let currentInfo, let onShowCurrentDetail {
+            let detailAction = UIAction(title: "查看详情", image: UIImage(systemName: "info.circle")) { _ in
+                onShowCurrentDetail(currentInfo)
+            }
+            actions.append(detailAction)
+        }
+
         if let setting = current.compactMap({ $0 as? UIMenu })
             .first(where: { $0.identifier == UIMenu.Identifier(rawValue: "setting") })
         {
             var child = setting.children
-            child.append(loopAction)
+            child.append(contentsOf: actions)
             if let index = current.firstIndex(of: setting) {
                 current[index] = setting.replacingChildren(child)
             }
             return []
         }
-        return [loopAction]
+        return actions
     }
 
     func playerDidEnd(player: AVPlayer) {
-        if !playNext() {
-            if Settings.loopPlay {
-                nextProvider?.reset()
-                if !playNext() {
-                    player.currentItem?.seek(to: .zero, completionHandler: nil)
-                    player.play()
+        Task { [weak self] in
+            guard let self else { return }
+            if !(await playNext()) {
+                if Settings.loopPlay {
+                    await MainActor.run {
+                        self.sequenceProvider?.reset()
+                    }
+                    if !(await playNext()) {
+                        player.currentItem?.seek(to: .zero, completionHandler: nil)
+                        player.play()
+                    }
+                    return
                 }
-                return
+                await MainActor.run { [weak self] in
+                    self?.onPlayEnd?()
+                }
             }
-            onPlayEnd?()
         }
     }
 
-    private func playNext() -> Bool {
-        if let next = nextProvider?.getNext() {
-            onPlayNextWithInfo?(next)
+    private func playPrevious() {
+        let previous = sequenceProvider.map { provider in
+            MainActor.assumeIsolated { provider.movePrevious() }
+        } ?? nil
+        if let previous {
+            Task { @MainActor in
+                self.onPlayPreviousWithInfo?(previous)
+            }
+        }
+    }
+
+    private func actionTitle(prefix: String, playInfo: PlayInfo) -> String {
+        // 由于 tvOS 系统信息面板容量有限，标题过长会导致部分按钮被截断丢弃。
+        // 所以我们现在只返回简短的前缀，例如 "上一条" / "下一条"
+        return prefix
+    }
+
+    @discardableResult
+    private func playNext() async -> Bool {
+        if let next = await sequenceProvider?.moveNext() {
+            await MainActor.run { [weak self] in
+                self?.onPlayNextWithInfo?(next)
+            }
             return true
         }
         return false

--- a/BilibiliLive/Component/Video/Plugins/VideoPlayListPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/VideoPlayListPlugin.swift
@@ -8,11 +8,9 @@
 import AVKit
 
 class VideoPlayListPlugin: NSObject, CommonPlayerPlugin {
-    private let previousActionIdentifierPrefix = "play.previous"
     private let nextActionIdentifierPrefix = "play.next"
     private weak var playerVC: AVPlayerViewController?
     var onPlayEnd: (() -> Void)?
-    var onPlayPreviousWithInfo: ((PlayInfo) -> Void)?
     var onPlayNextWithInfo: ((PlayInfo) -> Void)?
     var onShowCurrentDetail: ((PlayInfo) -> Void)?
 
@@ -38,8 +36,7 @@ class VideoPlayListPlugin: NSObject, CommonPlayerPlugin {
         }
 
         if let next {
-            let title = actionTitle(prefix: "下一条", playInfo: next)
-            let nextAction = UIAction(title: title,
+            let nextAction = UIAction(title: "下一条",
                                       image: UIImage(systemName: "forward.end.fill"),
                                       identifier: .init(rawValue: "\(nextActionIdentifierPrefix).\(next.sequenceKey)"))
             { [weak self] _ in
@@ -103,23 +100,6 @@ class VideoPlayListPlugin: NSObject, CommonPlayerPlugin {
                 }
             }
         }
-    }
-
-    private func playPrevious() {
-        let previous = sequenceProvider.map { provider in
-            MainActor.assumeIsolated { provider.movePrevious() }
-        } ?? nil
-        if let previous {
-            Task { @MainActor in
-                self.onPlayPreviousWithInfo?(previous)
-            }
-        }
-    }
-
-    private func actionTitle(prefix: String, playInfo: PlayInfo) -> String {
-        // 由于 tvOS 系统信息面板容量有限，标题过长会导致部分按钮被截断丢弃。
-        // 所以我们现在只返回简短的前缀，例如 "上一条" / "下一条"
-        return prefix
     }
 
     @discardableResult

--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -491,17 +491,15 @@ class VideoDetailViewController: UIViewController {
         let player = VideoPlayerViewController(playInfo: PlayInfo(aid: aid, cid: cid, epid: epid, seasonId: seasonId, subType: subType, lastPlayCid: lastPlayCid, playTimeInSecond: playTimeInSecond, title: data?.title))
         player.data = data
         if pages.count > 0, let index = pages.firstIndex(where: { $0.cid == cid }) {
-            let seq = pages.dropFirst(index).map({ PlayInfo(aid: aid, cid: $0.cid, epid: $0.epid, seasonId: seasonId, subType: subType, title: $0.part) })
+            let seq = pages.map({ PlayInfo(aid: aid, cid: $0.cid, epid: $0.epid, seasonId: seasonId, subType: subType, title: $0.part) })
             if seq.count > 0 {
-                let nextProvider = VideoNextProvider(seq: seq)
-                player.nextProvider = nextProvider
+                player.sequenceProvider = VideoSequenceProvider(seq: seq, currentIndex: index)
             }
         }
         if allUgcEpisodes.count > 0, let index = allUgcEpisodes.firstIndex(where: { $0.cid == cid }) {
-            let seq = allUgcEpisodes.dropFirst(index).map({ PlayInfo(aid: $0.aid, cid: $0.cid, title: $0.title) })
+            let seq = allUgcEpisodes.map({ PlayInfo(aid: $0.aid, cid: $0.cid, title: $0.title) })
             if seq.count > 0 {
-                let nextProvider = VideoNextProvider(seq: seq)
-                player.nextProvider = nextProvider
+                player.sequenceProvider = VideoSequenceProvider(seq: seq, currentIndex: index)
             }
         }
         present(player, animated: true, completion: nil)
@@ -598,10 +596,9 @@ extension VideoDetailViewController: UICollectionViewDelegate {
             let player = VideoPlayerViewController(playInfo: PlayInfo(aid: isBangumi ? page.page : aid, cid: page.cid, epid: page.epid, seasonId: seasonId, subType: subType, lastPlayCid: lastPlayCid, playTimeInSecond: playTimeInSecond, title: page.part))
             player.data = isBangumi ? nil : data
 
-            let seq = pages.dropFirst(indexPath.item).map({ PlayInfo(aid: isBangumi ? $0.page : aid, cid: $0.cid, epid: $0.epid, seasonId: seasonId, subType: subType, title: $0.part) })
+            let seq = pages.map({ PlayInfo(aid: isBangumi ? $0.page : aid, cid: $0.cid, epid: $0.epid, seasonId: seasonId, subType: subType, title: $0.part) })
             if seq.count > 0 {
-                let nextProvider = VideoNextProvider(seq: seq)
-                player.nextProvider = nextProvider
+                player.sequenceProvider = VideoSequenceProvider(seq: seq, currentIndex: indexPath.item)
             }
             present(player, animated: true, completion: nil)
         case replysCollectionView:

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -185,6 +185,7 @@ class VideoPlayerViewController: CommonPlayerViewController {
     private let viewModel: VideoPlayerViewModel
     private var cancelable = Set<AnyCancellable>()
     private var loadTask: Task<Void, Never>?
+    private var neighborPreloadTask: Task<Void, Never>?
     private var currentRetryKey: String
     private var hasRetriedCurrentItem = false
     private var isStopping = false
@@ -239,9 +240,10 @@ class VideoPlayerViewController: CommonPlayerViewController {
             case let .failure(err):
                 self?.handleLoadFailure(message: err)
             case let .success(plugins):
+                self?.neighborPreloadTask?.cancel()
                 self?.removeAllPlugins()
                 plugins.forEach { self?.addPlugin(plugin: $0) }
-                Task { [weak self] in
+                self?.neighborPreloadTask = Task { [weak self] in
                     await self?.viewModel.preloadNeighborsIfNeeded()
                 }
             }
@@ -327,6 +329,8 @@ class VideoPlayerViewController: CommonPlayerViewController {
     }
 
     private func handlePlayInfoChanged(_ info: PlayInfo) {
+        neighborPreloadTask?.cancel()
+        neighborPreloadTask = nil
         if playMode == .feedFlow,
            let watchSignal = consumeCurrentPlaybackWatchSignal()
         {
@@ -354,6 +358,8 @@ class VideoPlayerViewController: CommonPlayerViewController {
         activeWatchSignalPlayInfo = nil
         loadTask?.cancel()
         loadTask = nil
+        neighborPreloadTask?.cancel()
+        neighborPreloadTask = nil
         viewModel.cancelLoading()
         cancelable.removeAll()
         Task { [mediaWarmupManager] in

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -35,6 +35,12 @@ struct PlayInfo: Hashable {
         "\(aid)-\(cid ?? 0)-\(epid ?? 0)-\(seasonId ?? 0)"
     }
 
+    var contentIdentity: String {
+        if let epid, epid > 0 { return "epid-\(epid)" }
+        if let seasonId, seasonId > 0 { return "season-\(seasonId)" }
+        return "aid-\(aid)"
+    }
+
     var contextKey: PlayContextKey {
         PlayContextKey(aid: aid,
                        cid: cid ?? 0,
@@ -348,6 +354,7 @@ class VideoPlayerViewController: CommonPlayerViewController {
         activeWatchSignalPlayInfo = nil
         loadTask?.cancel()
         loadTask = nil
+        viewModel.cancelLoading()
         cancelable.removeAll()
         Task { [mediaWarmupManager] in
             await mediaWarmupManager?.cancelAll()

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -9,8 +9,8 @@ import AVKit
 import Combine
 import UIKit
 
-struct PlayInfo {
-    let aid: Int
+struct PlayInfo: Hashable {
+    var aid: Int
     var cid: Int? = 0
     var epid: Int? = 0 // 港澳台解锁需要
     var seasonId: Int? = 0 // 番剧 season_id
@@ -19,6 +19,9 @@ struct PlayInfo {
     var lastPlayCid: Int?
     var playTimeInSecond: Int?
     var title: String?
+    var ownerName: String?
+    var coverURL: URL?
+    var duration: Int?
 
     var isCidVaild: Bool {
         return cid ?? 0 > 0
@@ -27,47 +30,184 @@ struct PlayInfo {
     var isBangumi: Bool {
         return epid ?? 0 > 0 || seasonId ?? 0 > 0
     }
-}
 
-class VideoNextProvider {
-    init(seq: [PlayInfo]) {
-        playSeq = seq
+    var sequenceKey: String {
+        "\(aid)-\(cid ?? 0)-\(epid ?? 0)-\(seasonId ?? 0)"
     }
 
-    private var index = 0
-    private let playSeq: [PlayInfo]
+    var contextKey: PlayContextKey {
+        PlayContextKey(aid: aid,
+                       cid: cid ?? 0,
+                       epid: epid ?? 0,
+                       seasonId: seasonId ?? 0)
+    }
+}
+
+enum VideoPlayerMode {
+    case regular
+    case preview
+    case feedFlow
+}
+
+@MainActor
+final class VideoSequenceProvider {
+    private(set) var playSeq: [PlayInfo]
+    private(set) var currentIndex: Int
+    private(set) var temporaryOverrides = [PlayInfo]()
+    private let preloadThreshold: Int
+    var onNeedMore: (() async -> Void)?
+
+    init(seq: [PlayInfo], currentIndex: Int = 0, preloadThreshold: Int = 8) {
+        playSeq = seq.uniqued()
+        self.currentIndex = max(0, min(currentIndex, max(playSeq.count - 1, 0)))
+        self.preloadThreshold = preloadThreshold
+    }
+
     var count: Int {
-        return playSeq.count
+        playSeq.count
+    }
+
+    var hasPrevious: Bool {
+        currentIndex > 0
+    }
+
+    var hasNext: Bool {
+        currentIndex + 1 < playSeq.count
+    }
+
+    func current() -> PlayInfo? {
+        if let temporary = temporaryOverrides.last {
+            return temporary
+        }
+        guard playSeq.indices.contains(currentIndex) else { return nil }
+        return playSeq[currentIndex]
+    }
+
+    func setCurrentIndex(_ index: Int) {
+        guard playSeq.indices.contains(index) else { return }
+        clearTemporaryOverrides()
+        currentIndex = index
     }
 
     func reset() {
-        index = 0
+        clearTemporaryOverrides()
+        currentIndex = 0
     }
 
-    func getNext() -> PlayInfo? {
-        index += 1
-        if index < playSeq.count {
-            return playSeq[index]
-        }
-        return nil
+    func append(_ seq: [PlayInfo]) {
+        var existing = Set(playSeq.map(\.sequenceKey))
+        let newItems = seq.filter { existing.insert($0.sequenceKey).inserted }
+        playSeq.append(contentsOf: newItems)
+    }
+
+    func peekPrevious() -> PlayInfo? {
+        guard hasPrevious else { return nil }
+        return playSeq[currentIndex - 1]
     }
 
     func peekNext() -> PlayInfo? {
-        let nextIndex = index + 1
-        if nextIndex < playSeq.count {
-            return playSeq[nextIndex]
-        }
-        return nil
+        guard hasNext else { return nil }
+        return playSeq[currentIndex + 1]
+    }
+
+    func neighborItems(radius: Int) -> [PlayInfo] {
+        guard !playSeq.isEmpty else { return temporaryOverrides.uniqued() }
+        let lower = max(0, currentIndex - radius)
+        let upper = min(playSeq.count - 1, currentIndex + radius)
+        return ([current()].compactMap { $0 } + Array(playSeq[lower...upper])).uniqued()
+    }
+
+    func pushTemporary(_ playInfo: PlayInfo) {
+        temporaryOverrides.append(playInfo)
+    }
+
+    func clearTemporaryOverrides() {
+        temporaryOverrides.removeAll()
+    }
+
+    func movePrevious() -> PlayInfo? {
+        guard hasPrevious else { return nil }
+        clearTemporaryOverrides()
+        currentIndex -= 1
+        return playSeq[currentIndex]
+    }
+
+    func moveNext() async -> PlayInfo? {
+        await prefetchMoreIfNeeded()
+        guard hasNext else { return nil }
+        clearTemporaryOverrides()
+        currentIndex += 1
+        await prefetchMoreIfNeeded()
+        return playSeq[currentIndex]
+    }
+
+    func prefetchMoreIfNeeded() async {
+        guard count - currentIndex - 1 < preloadThreshold else { return }
+        await onNeedMore?()
     }
 }
 
 class VideoPlayerViewController: CommonPlayerViewController {
-    var data: VideoDetail?
-    var nextProvider: VideoNextProvider?
+    enum AutoTriggeredInfoAction: String {
+        case previous
+        case next
 
-    init(playInfo: PlayInfo) {
-        viewModel = VideoPlayerViewModel(playInfo: playInfo)
+        init?(title: String) {
+            let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedTitle.contains("上一条") {
+                self = .previous
+            } else if trimmedTitle.contains("下一条") {
+                self = .next
+            } else {
+                return nil
+            }
+        }
+    }
+
+    var data: VideoDetail?
+    var sequenceProvider: VideoSequenceProvider?
+    var onLoadFailure: ((String) -> Void)?
+    var onPlaybackStarted: (() -> Void)?
+    var onPlayInfoChanged: ((PlayInfo) -> Void)?
+    var onDismissWithPlayInfo: ((PlayInfo) -> Void)?
+    var onItemWatched: ((PlayInfo, Int) -> Void)?
+
+    private let playMode: VideoPlayerMode
+    private let playContextCache: PlayContextCache?
+    private let mediaWarmupManager: PlayerMediaWarmupManager?
+    private let previewMuted: Bool
+    private let viewModel: VideoPlayerViewModel
+    private var cancelable = Set<AnyCancellable>()
+    private var loadTask: Task<Void, Never>?
+    private var currentRetryKey: String
+    private var hasRetriedCurrentItem = false
+    private var isStopping = false
+    private var activeWatchSignalPlayInfo: PlayInfo?
+    private var pendingAutoTriggeredInfoActionKey: String?
+
+    init(playInfo: PlayInfo,
+         playMode: VideoPlayerMode = .regular,
+         playContextCache: PlayContextCache? = nil,
+         mediaWarmupManager: PlayerMediaWarmupManager? = nil,
+         previewMuted: Bool = true,
+         startTimeOverride: Int? = nil)
+    {
+        self.playMode = playMode
+        self.playContextCache = playContextCache
+        self.mediaWarmupManager = mediaWarmupManager
+        self.previewMuted = previewMuted
+        viewModel = VideoPlayerViewModel(playInfo: playInfo,
+                                         playMode: playMode,
+                                         playContextCache: playContextCache,
+                                         mediaWarmupManager: mediaWarmupManager,
+                                         previewMuted: previewMuted,
+                                         startTimeOverride: startTimeOverride)
+        currentRetryKey = playInfo.sequenceKey
         super.init(nibName: nil, bundle: nil)
+        if playMode == .preview {
+            showsPlaybackControls = false
+            allowsPictureInPicturePlayback = false
+        }
     }
 
     @available(*, unavailable)
@@ -75,29 +215,402 @@ class VideoPlayerViewController: CommonPlayerViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private let viewModel: VideoPlayerViewModel
-    private var cancelable = Set<AnyCancellable>()
+    var currentPlayInfo: PlayInfo {
+        viewModel.currentPlayInfo
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel.nextProvider = nextProvider
+        viewModel.sequenceProvider = sequenceProvider
+        viewModel.onPlayInfoChanged = { [weak self] info in
+            self?.handlePlayInfoChanged(info)
+        }
+        viewModel.onShowDetail = { [weak self] info in
+            self?.showDetail(for: info)
+        }
         viewModel.onPluginReady.receive(on: DispatchQueue.main).sink { [weak self] completion in
             switch completion {
             case let .failure(err):
-                self?.showErrorAlertAndExit(message: err)
+                self?.handleLoadFailure(message: err)
             default:
                 break
             }
         } receiveValue: { [weak self] plugins in
             self?.removeAllPlugins()
             plugins.forEach { self?.addPlugin(plugin: $0) }
+            Task { [weak self] in
+                await self?.viewModel.preloadNeighborsIfNeeded()
+            }
         }.store(in: &cancelable)
 
-        viewModel.onExit = { [weak self] in
-            self?.dismiss(animated: true)
+        if playMode == .regular {
+            viewModel.onExit = { [weak self] in
+                self?.dismiss(animated: true)
+            }
         }
-        Task {
-            await viewModel.load()
+
+        if playMode == .feedFlow {
+            // 添加双击上方向键切回上一条视频的全局手势拦截 (作为面板“上一条”被折叠的补偿方案)
+            let doubleUpTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleUpTap))
+            doubleUpTap.allowedPressTypes = [NSNumber(value: UIPress.PressType.upArrow.rawValue)]
+            doubleUpTap.numberOfTapsRequired = 2
+            view.addGestureRecognizer(doubleUpTap)
+
+            let doubleDownTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleDownTap))
+            doubleDownTap.allowedPressTypes = [NSNumber(value: UIPress.PressType.downArrow.rawValue)]
+            doubleDownTap.numberOfTapsRequired = 2
+            view.addGestureRecognizer(doubleDownTap)
+
+            NotificationCenter.default.addObserver(self,
+                                                   selector: #selector(handleInfoActionFocusedNotification(_:)),
+                                                   name: UICollectionViewCell.infoActionFocusedNotification,
+                                                   object: nil)
+            if #available(tvOS 11.0, *) {
+                NotificationCenter.default.addObserver(self,
+                                                       selector: #selector(handleSystemFocusUpdate(_:)),
+                                                       name: UIFocusSystem.didUpdateNotification,
+                                                       object: nil)
+            }
+        }
+
+        startLoad()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        let isExiting = isBeingDismissed || isMovingFromParent || navigationController?.isBeingDismissed == true
+        let exitWatchSignal = isExiting ? consumeCurrentPlaybackWatchSignal() : nil
+        let dismissPlayInfo = playMode == .feedFlow ? viewModel.currentPlayInfo : nil
+        super.viewDidDisappear(animated)
+        guard isExiting else { return }
+        if playMode == .feedFlow {
+            if let exitWatchSignal {
+                onItemWatched?(exitWatchSignal.0, exitWatchSignal.1)
+            }
+            if let dismissPlayInfo {
+                onDismissWithPlayInfo?(dismissPlayInfo)
+            }
+        }
+        stopAsyncWork()
+    }
+
+    override func stopPlayback() {
+        stopAsyncWork()
+        super.stopPlayback()
+    }
+
+    override func playerDidStart(player: AVPlayer) {
+        switch playMode {
+        case .preview:
+            onPlaybackStarted?()
+        case .feedFlow:
+            activeWatchSignalPlayInfo = viewModel.currentPlayInfo
+        case .regular:
+            break
+        }
+    }
+
+    override func playerDidStall(player: AVPlayer) {
+        guard playMode == .feedFlow else { return }
+        attemptRetryOrShowRecovery(message: "播放卡住了，请选择重试或切换下一条。")
+    }
+
+    override func playerDidFail(player: AVPlayer) {
+        guard playMode == .feedFlow else {
+            super.playerDidFail(player: player)
+            return
+        }
+        attemptRetryOrShowRecovery(message: "当前视频加载失败，请选择重试或切换下一条。")
+    }
+
+    private func handlePlayInfoChanged(_ info: PlayInfo) {
+        if playMode == .feedFlow,
+           let watchSignal = consumeCurrentPlaybackWatchSignal()
+        {
+            onItemWatched?(watchSignal.0, watchSignal.1)
+        }
+        if currentRetryKey != info.sequenceKey {
+            currentRetryKey = info.sequenceKey
+            hasRetriedCurrentItem = false
+        }
+        pendingAutoTriggeredInfoActionKey = nil
+        onPlayInfoChanged?(info)
+    }
+
+    private func startLoad() {
+        loadTask?.cancel()
+        guard !isStopping else { return }
+        loadTask = Task { [weak self] in
+            await self?.viewModel.load()
+        }
+    }
+
+    private func stopAsyncWork() {
+        guard !isStopping else { return }
+        isStopping = true
+        activeWatchSignalPlayInfo = nil
+        loadTask?.cancel()
+        loadTask = nil
+        cancelable.removeAll()
+        Task { [mediaWarmupManager] in
+            await mediaWarmupManager?.cancelAll()
+        }
+    }
+
+    private func consumeCurrentPlaybackWatchSignal() -> (PlayInfo, Int)? {
+        defer { activeWatchSignalPlayInfo = nil }
+        guard let playInfo = activeWatchSignalPlayInfo,
+              let watchedSeconds = currentPlaybackTimeInSeconds()
+        else {
+            return nil
+        }
+        return (playInfo, watchedSeconds)
+    }
+
+    private func handleLoadFailure(message: String) {
+        switch playMode {
+        case .preview:
+            onLoadFailure?(message)
+        case .feedFlow:
+            attemptRetryOrShowRecovery(message: message)
+        case .regular:
+            showErrorAlertAndExit(message: message)
+        }
+    }
+
+    private func attemptRetryOrShowRecovery(message: String) {
+        guard !hasRetriedCurrentItem else {
+            showFeedFlowRecoveryAlert(message: message)
+            return
+        }
+        hasRetriedCurrentItem = true
+        Task { [weak self] in
+            await self?.viewModel.retryCurrent()
+        }
+    }
+
+    private func showFeedFlowRecoveryAlert(message: String) {
+        let alert = UIAlertController(title: "播放异常", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "重试", style: .default) { [weak self] _ in
+            self?.hasRetriedCurrentItem = true
+            Task { [weak self] in
+                await self?.viewModel.retryCurrent()
+            }
+        })
+        alert.addAction(UIAlertAction(title: "下一条", style: .default) { [weak self] _ in
+            Task { [weak self] in
+                if await self?.viewModel.playNextFromSequence() == false {
+                    self?.dismiss(animated: true)
+                }
+            }
+        })
+        alert.addAction(UIAlertAction(title: "关闭", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func showDetail(for info: PlayInfo) {
+        guard playMode != .preview else { return }
+        let detailVC: VideoDetailViewController
+        if let seasonId = info.seasonId, seasonId > 0 {
+            detailVC = VideoDetailViewController.create(seasonId: seasonId)
+        } else {
+            detailVC = VideoDetailViewController.create(aid: info.aid, cid: info.cid, epid: info.epid)
+        }
+        detailVC.present(from: self, direatlyEnterVideo: false)
+    }
+
+    @objc private func handleDoubleUpTap() {
+        guard playMode == .feedFlow else { return }
+        Logger.debug("[FeedFlow] 捕获双击上键，准备切换至上一条")
+        Task { [weak self] in
+            guard let self else { return }
+            _ = await self.viewModel.playPreviousFromSequence()
+        }
+    }
+
+    @objc private func handleDoubleDownTap() {
+        guard playMode == .feedFlow else { return }
+        Logger.debug("[FeedFlow] 捕获双击下键，准备切换至下一条")
+        Task { [weak self] in
+            guard let self else { return }
+            _ = await self.viewModel.playNextFromSequence()
+        }
+    }
+
+    @available(tvOS 11.0, *)
+    @objc private func handleSystemFocusUpdate(_ note: Notification) {
+        guard playMode == .feedFlow,
+              let context = note.userInfo?[UIFocusSystem.focusUpdateContextUserInfoKey] as? UIFocusUpdateContext,
+              let nextView = context.nextFocusedView
+        else { return }
+
+        refreshAVInfoPanelHookIfNeeded(for: nextView)
+        #if DEBUG
+            Logger.debug("[FocusDiag] 焦点落在了类: \(type(of: nextView))")
+            let dumpResult = dumpViewHierarchy(nextView, depth: 0)
+            Logger.debug("[FocusDiag] 子视图结构:\n\(dumpResult)")
+        #endif
+
+        if let title = extractMatchingActionTitle(from: nextView) {
+            handleFocusedInfoAction(title: title)
+        }
+    }
+
+    #if DEBUG
+        private func dumpViewHierarchy(_ view: UIView, depth: Int) -> String {
+            guard depth < 6 else { return "" }
+            let indent = String(repeating: "  ", count: depth)
+            var result = "\(indent)- \(type(of: view))"
+            if let label = view as? UILabel {
+                result += " text: '\(label.text ?? "")' attr: '\(label.attributedText?.string ?? "")'"
+            } else if let btn = view as? UIButton {
+                result += " title: '\(btn.title(for: .normal) ?? "")'"
+            }
+            result += "\n"
+            for subview in view.subviews {
+                result += dumpViewHierarchy(subview, depth: depth + 1)
+            }
+            return result
+        }
+    #endif
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        guard playMode == .feedFlow,
+              let nextView = context.nextFocusedView
+        else { return }
+
+        refreshAVInfoPanelHookIfNeeded(for: nextView)
+        // 从 focused view 的子视图树中查找匹配的 action 标题
+        if let title = extractMatchingActionTitle(from: nextView) {
+            #if DEBUG
+                Logger.debug("[FeedFlow] didUpdateFocus matched action: \(title)")
+            #endif
+            handleFocusedInfoAction(title: title)
+        }
+    }
+
+    private func extractMatchingActionTitle(from view: UIView) -> String? {
+        if let title = extractActionTitle(in: view) {
+            return title
+        }
+        for ancestor in candidateTitleContainers(for: view) {
+            if let title = extractActionTitle(in: ancestor) {
+                return title
+            }
+        }
+        return nil
+    }
+
+    private func extractActionTitle(in view: UIView) -> String? {
+        if let accessLabel = view.accessibilityLabel, AutoTriggeredInfoAction(title: accessLabel) != nil {
+            return accessLabel
+        }
+        if let label = view as? UILabel {
+            if let text = label.text, AutoTriggeredInfoAction(title: text) != nil {
+                return text
+            }
+            if let attrText = label.attributedText?.string, AutoTriggeredInfoAction(title: attrText) != nil {
+                return attrText
+            }
+        }
+        if let button = view as? UIButton {
+            let candidateTitles = [button.title(for: .focused), button.title(for: .normal)]
+            for title in candidateTitles.compactMap({ $0 }) where AutoTriggeredInfoAction(title: title) != nil {
+                return title
+            }
+        }
+        for label in collectLabels(in: view, maxDepth: 4) {
+            if let text = label.text, AutoTriggeredInfoAction(title: text) != nil {
+                return text
+            }
+            if let attrText = label.attributedText?.string, AutoTriggeredInfoAction(title: attrText) != nil {
+                return attrText
+            }
+        }
+        return nil
+    }
+
+    private func candidateTitleContainers(for view: UIView) -> [UIView] {
+        var containers = [UIView]()
+        var seen = Set<ObjectIdentifier>()
+        var currentView = view.superview
+        var remainingDepth = 6
+
+        while let ancestorView = currentView, remainingDepth > 0 {
+            let isInfoPanelContainer = ancestorView is UICollectionViewCell ||
+                NSStringFromClass(type(of: ancestorView)).contains("AVInfoPanel")
+            if isInfoPanelContainer {
+                let identifier = ObjectIdentifier(ancestorView)
+                if !seen.contains(identifier) {
+                    seen.insert(identifier)
+                    containers.append(ancestorView)
+                }
+            }
+            remainingDepth -= 1
+            currentView = ancestorView.superview
+        }
+
+        return containers
+    }
+
+    private func refreshAVInfoPanelHookIfNeeded(for view: UIView) {
+        guard containsAVInfoPanelHierarchy(from: view) else { return }
+        AVInfoPanelCollectionViewThumbnailCellHook.start()
+    }
+
+    private func containsAVInfoPanelHierarchy(from view: UIView) -> Bool {
+        var currentView: UIView? = view
+        var remainingDepth = 8
+
+        while let ancestorView = currentView, remainingDepth > 0 {
+            if NSStringFromClass(type(of: ancestorView)).contains("AVInfoPanel") {
+                return true
+            }
+            remainingDepth -= 1
+            currentView = ancestorView.superview
+        }
+
+        return false
+    }
+
+    private func collectLabels(in view: UIView, maxDepth: Int) -> [UILabel] {
+        guard maxDepth > 0 else { return [] }
+        var result = [UILabel]()
+        for subview in view.subviews {
+            if let label = subview as? UILabel {
+                result.append(label)
+            }
+            result.append(contentsOf: collectLabels(in: subview, maxDepth: maxDepth - 1))
+        }
+        return result
+    }
+
+    @objc private func handleInfoActionFocusedNotification(_ note: Notification) {
+        guard let title = note.userInfo?["title"] as? String else { return }
+        handleFocusedInfoAction(title: title)
+    }
+
+    private func handleFocusedInfoAction(title: String) {
+        guard playMode == .feedFlow,
+              let action = AutoTriggeredInfoAction(title: title)
+        else { return }
+
+        let actionKey = "\(currentPlayInfo.sequenceKey)::\(action.rawValue)"
+        guard pendingAutoTriggeredInfoActionKey != actionKey else { return }
+        pendingAutoTriggeredInfoActionKey = actionKey
+
+        Task { [weak self] in
+            guard let self else { return }
+            let didTrigger: Bool
+            switch action {
+            case .previous:
+                didTrigger = await self.viewModel.playPreviousFromSequence()
+            case .next:
+                didTrigger = await self.viewModel.playNextFromSequence()
+            }
+            if !didTrigger, self.pendingAutoTriggeredInfoActionKey == actionKey {
+                self.pendingAutoTriggeredInfoActionKey = nil
+            }
         }
     }
 }

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -228,18 +228,16 @@ class VideoPlayerViewController: CommonPlayerViewController {
         viewModel.onShowDetail = { [weak self] info in
             self?.showDetail(for: info)
         }
-        viewModel.onPluginReady.receive(on: DispatchQueue.main).sink { [weak self] completion in
-            switch completion {
+        viewModel.loadResult.receive(on: DispatchQueue.main).sink { [weak self] result in
+            switch result {
             case let .failure(err):
                 self?.handleLoadFailure(message: err)
-            default:
-                break
-            }
-        } receiveValue: { [weak self] plugins in
-            self?.removeAllPlugins()
-            plugins.forEach { self?.addPlugin(plugin: $0) }
-            Task { [weak self] in
-                await self?.viewModel.preloadNeighborsIfNeeded()
+            case let .success(plugins):
+                self?.removeAllPlugins()
+                plugins.forEach { self?.addPlugin(plugin: $0) }
+                Task { [weak self] in
+                    await self?.viewModel.preloadNeighborsIfNeeded()
+                }
             }
         }.store(in: &cancelable)
 

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -414,7 +414,7 @@ class VideoPlayerViewController: CommonPlayerViewController {
               let nextView = context.nextFocusedView
         else { return }
 
-        refreshAVInfoPanelHookIfNeeded(for: nextView)
+        installAVInfoPanelHookIfNeeded(for: nextView)
         #if DEBUG
             Logger.debug("[FocusDiag] 焦点落在了类: \(type(of: nextView))")
             let dumpResult = dumpViewHierarchy(nextView, depth: 0)
@@ -440,9 +440,12 @@ class VideoPlayerViewController: CommonPlayerViewController {
         }
     #endif
 
-    private func refreshAVInfoPanelHookIfNeeded(for view: UIView) {
+    private func installAVInfoPanelHookIfNeeded(for view: UIView) {
         guard containsAVInfoPanelHierarchy(from: view) else { return }
-        AVInfoPanelCollectionViewThumbnailCellHook.start()
+        guard AVInfoPanelCollectionViewThumbnailCellHook.start(),
+              let title = extractInfoActionTitle(from: view)
+        else { return }
+        handleFocusedInfoAction(title: title)
     }
 
     private func containsAVInfoPanelHierarchy(from view: UIView) -> Bool {
@@ -458,6 +461,48 @@ class VideoPlayerViewController: CommonPlayerViewController {
         }
 
         return false
+    }
+
+    private func extractInfoActionTitle(from view: UIView) -> String? {
+        var currentView: UIView? = view
+        var remainingDepth = 8
+
+        while let candidate = currentView, remainingDepth > 0 {
+            if let title = matchingInfoActionTitle(in: candidate, maxDepth: 0) {
+                return title
+            }
+            let isActionContainer = candidate is UICollectionViewCell ||
+                NSStringFromClass(type(of: candidate)).contains("AVInfoPanel")
+            if isActionContainer,
+               let title = matchingInfoActionTitle(in: candidate, maxDepth: 4)
+            {
+                return title
+            }
+            remainingDepth -= 1
+            currentView = candidate.superview
+        }
+        return nil
+    }
+
+    private func matchingInfoActionTitle(in view: UIView, maxDepth: Int) -> String? {
+        let titles: [String?]
+        if let label = view as? UILabel {
+            titles = [label.text, label.attributedText?.string, label.accessibilityLabel]
+        } else if let button = view as? UIButton {
+            titles = [button.title(for: .focused), button.title(for: .normal), button.accessibilityLabel]
+        } else {
+            titles = [view.accessibilityLabel]
+        }
+        if let title = titles.compactMap({ $0 }).first(where: { AutoTriggeredInfoAction(title: $0) != nil }) {
+            return title
+        }
+        guard maxDepth > 0 else { return nil }
+        for subview in view.subviews {
+            if let title = matchingInfoActionTitle(in: subview, maxDepth: maxDepth - 1) {
+                return title
+            }
+        }
+        return nil
     }
 
     @objc private func handleInfoActionFocusedNotification(_ note: Notification) {

--- a/BilibiliLive/Component/Video/VideoPlayerViewController.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewController.swift
@@ -21,7 +21,6 @@ struct PlayInfo: Hashable {
     var title: String?
     var ownerName: String?
     var coverURL: URL?
-    var duration: Int?
 
     var isCidVaild: Bool {
         return cid ?? 0 > 0
@@ -176,7 +175,6 @@ class VideoPlayerViewController: CommonPlayerViewController {
     var onPlaybackStarted: (() -> Void)?
     var onPlayInfoChanged: ((PlayInfo) -> Void)?
     var onDismissWithPlayInfo: ((PlayInfo) -> Void)?
-    var onItemWatched: ((PlayInfo, Int) -> Void)?
 
     private let playMode: VideoPlayerMode
     private let playContextCache: PlayContextCache?
@@ -184,12 +182,10 @@ class VideoPlayerViewController: CommonPlayerViewController {
     private let previewMuted: Bool
     private let viewModel: VideoPlayerViewModel
     private var cancelable = Set<AnyCancellable>()
-    private var loadTask: Task<Void, Never>?
     private var neighborPreloadTask: Task<Void, Never>?
     private var currentRetryKey: String
     private var hasRetriedCurrentItem = false
     private var isStopping = false
-    private var activeWatchSignalPlayInfo: PlayInfo?
     private var pendingAutoTriggeredInfoActionKey: String?
 
     init(playInfo: PlayInfo,
@@ -279,19 +275,15 @@ class VideoPlayerViewController: CommonPlayerViewController {
             }
         }
 
-        startLoad()
+        viewModel.load()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         let isExiting = isBeingDismissed || isMovingFromParent || navigationController?.isBeingDismissed == true
-        let exitWatchSignal = isExiting ? consumeCurrentPlaybackWatchSignal() : nil
         let dismissPlayInfo = playMode == .feedFlow ? viewModel.currentPlayInfo : nil
         super.viewDidDisappear(animated)
         guard isExiting else { return }
         if playMode == .feedFlow {
-            if let exitWatchSignal {
-                onItemWatched?(exitWatchSignal.0, exitWatchSignal.1)
-            }
             if let dismissPlayInfo {
                 onDismissWithPlayInfo?(dismissPlayInfo)
             }
@@ -308,9 +300,7 @@ class VideoPlayerViewController: CommonPlayerViewController {
         switch playMode {
         case .preview:
             onPlaybackStarted?()
-        case .feedFlow:
-            activeWatchSignalPlayInfo = viewModel.currentPlayInfo
-        case .regular:
+        case .feedFlow, .regular:
             break
         }
     }
@@ -331,11 +321,6 @@ class VideoPlayerViewController: CommonPlayerViewController {
     private func handlePlayInfoChanged(_ info: PlayInfo) {
         neighborPreloadTask?.cancel()
         neighborPreloadTask = nil
-        if playMode == .feedFlow,
-           let watchSignal = consumeCurrentPlaybackWatchSignal()
-        {
-            onItemWatched?(watchSignal.0, watchSignal.1)
-        }
         if currentRetryKey != info.sequenceKey {
             currentRetryKey = info.sequenceKey
             hasRetriedCurrentItem = false
@@ -344,20 +329,9 @@ class VideoPlayerViewController: CommonPlayerViewController {
         onPlayInfoChanged?(info)
     }
 
-    private func startLoad() {
-        loadTask?.cancel()
-        guard !isStopping else { return }
-        loadTask = Task { [weak self] in
-            await self?.viewModel.load()
-        }
-    }
-
     private func stopAsyncWork() {
         guard !isStopping else { return }
         isStopping = true
-        activeWatchSignalPlayInfo = nil
-        loadTask?.cancel()
-        loadTask = nil
         neighborPreloadTask?.cancel()
         neighborPreloadTask = nil
         viewModel.cancelLoading()
@@ -365,16 +339,6 @@ class VideoPlayerViewController: CommonPlayerViewController {
         Task { [mediaWarmupManager] in
             await mediaWarmupManager?.cancelAll()
         }
-    }
-
-    private func consumeCurrentPlaybackWatchSignal() -> (PlayInfo, Int)? {
-        defer { activeWatchSignalPlayInfo = nil }
-        guard let playInfo = activeWatchSignalPlayInfo,
-              let watchedSeconds = currentPlaybackTimeInSeconds()
-        else {
-            return nil
-        }
-        return (playInfo, watchedSeconds)
     }
 
     private func handleLoadFailure(message: String) {
@@ -394,18 +358,14 @@ class VideoPlayerViewController: CommonPlayerViewController {
             return
         }
         hasRetriedCurrentItem = true
-        Task { [weak self] in
-            await self?.viewModel.retryCurrent()
-        }
+        viewModel.retryCurrent()
     }
 
     private func showFeedFlowRecoveryAlert(message: String) {
         let alert = UIAlertController(title: "播放异常", message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "重试", style: .default) { [weak self] _ in
             self?.hasRetriedCurrentItem = true
-            Task { [weak self] in
-                await self?.viewModel.retryCurrent()
-            }
+            self?.viewModel.retryCurrent()
         })
         alert.addAction(UIAlertAction(title: "下一条", style: .default) { [weak self] _ in
             Task { [weak self] in
@@ -460,10 +420,6 @@ class VideoPlayerViewController: CommonPlayerViewController {
             let dumpResult = dumpViewHierarchy(nextView, depth: 0)
             Logger.debug("[FocusDiag] 子视图结构:\n\(dumpResult)")
         #endif
-
-        if let title = extractMatchingActionTitle(from: nextView) {
-            handleFocusedInfoAction(title: title)
-        }
     }
 
     #if DEBUG
@@ -484,86 +440,6 @@ class VideoPlayerViewController: CommonPlayerViewController {
         }
     #endif
 
-    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        super.didUpdateFocus(in: context, with: coordinator)
-        guard playMode == .feedFlow,
-              let nextView = context.nextFocusedView
-        else { return }
-
-        refreshAVInfoPanelHookIfNeeded(for: nextView)
-        // 从 focused view 的子视图树中查找匹配的 action 标题
-        if let title = extractMatchingActionTitle(from: nextView) {
-            #if DEBUG
-                Logger.debug("[FeedFlow] didUpdateFocus matched action: \(title)")
-            #endif
-            handleFocusedInfoAction(title: title)
-        }
-    }
-
-    private func extractMatchingActionTitle(from view: UIView) -> String? {
-        if let title = extractActionTitle(in: view) {
-            return title
-        }
-        for ancestor in candidateTitleContainers(for: view) {
-            if let title = extractActionTitle(in: ancestor) {
-                return title
-            }
-        }
-        return nil
-    }
-
-    private func extractActionTitle(in view: UIView) -> String? {
-        if let accessLabel = view.accessibilityLabel, AutoTriggeredInfoAction(title: accessLabel) != nil {
-            return accessLabel
-        }
-        if let label = view as? UILabel {
-            if let text = label.text, AutoTriggeredInfoAction(title: text) != nil {
-                return text
-            }
-            if let attrText = label.attributedText?.string, AutoTriggeredInfoAction(title: attrText) != nil {
-                return attrText
-            }
-        }
-        if let button = view as? UIButton {
-            let candidateTitles = [button.title(for: .focused), button.title(for: .normal)]
-            for title in candidateTitles.compactMap({ $0 }) where AutoTriggeredInfoAction(title: title) != nil {
-                return title
-            }
-        }
-        for label in collectLabels(in: view, maxDepth: 4) {
-            if let text = label.text, AutoTriggeredInfoAction(title: text) != nil {
-                return text
-            }
-            if let attrText = label.attributedText?.string, AutoTriggeredInfoAction(title: attrText) != nil {
-                return attrText
-            }
-        }
-        return nil
-    }
-
-    private func candidateTitleContainers(for view: UIView) -> [UIView] {
-        var containers = [UIView]()
-        var seen = Set<ObjectIdentifier>()
-        var currentView = view.superview
-        var remainingDepth = 6
-
-        while let ancestorView = currentView, remainingDepth > 0 {
-            let isInfoPanelContainer = ancestorView is UICollectionViewCell ||
-                NSStringFromClass(type(of: ancestorView)).contains("AVInfoPanel")
-            if isInfoPanelContainer {
-                let identifier = ObjectIdentifier(ancestorView)
-                if !seen.contains(identifier) {
-                    seen.insert(identifier)
-                    containers.append(ancestorView)
-                }
-            }
-            remainingDepth -= 1
-            currentView = ancestorView.superview
-        }
-
-        return containers
-    }
-
     private func refreshAVInfoPanelHookIfNeeded(for view: UIView) {
         guard containsAVInfoPanelHierarchy(from: view) else { return }
         AVInfoPanelCollectionViewThumbnailCellHook.start()
@@ -582,18 +458,6 @@ class VideoPlayerViewController: CommonPlayerViewController {
         }
 
         return false
-    }
-
-    private func collectLabels(in view: UIView, maxDepth: Int) -> [UILabel] {
-        guard maxDepth > 0 else { return [] }
-        var result = [UILabel]()
-        for subview in view.subviews {
-            if let label = subview as? UILabel {
-                result.append(label)
-            }
-            result.append(contentsOf: collectLabels(in: subview, maxDepth: maxDepth - 1))
-        }
-        return result
     }
 
     @objc private func handleInfoActionFocusedNotification(_ note: Notification) {

--- a/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
@@ -66,8 +66,8 @@ class VideoPlayerViewModel {
         playInfo
     }
 
-    func load() async {
-        await startLoad(for: playInfo).value
+    func load() {
+        startLoad(for: playInfo)
     }
 
     func cancelLoading() {
@@ -76,8 +76,7 @@ class VideoPlayerViewModel {
         loadGeneration += 1
     }
 
-    @discardableResult
-    private func startLoad(for requestedPlayInfo: PlayInfo) -> Task<Void, Never> {
+    private func startLoad(for requestedPlayInfo: PlayInfo) {
         loadTask?.cancel()
         loadGeneration += 1
         let generation = loadGeneration
@@ -86,7 +85,6 @@ class VideoPlayerViewModel {
             await performLoad(for: requestedPlayInfo, generation: generation)
         }
         loadTask = task
-        return task
     }
 
     private func performLoad(for requestedPlayInfo: PlayInfo, generation: Int) async {
@@ -241,8 +239,8 @@ class VideoPlayerViewModel {
         return nil
     }
 
-    func retryCurrent() async {
-        await load()
+    func retryCurrent() {
+        load()
     }
 
     func playNextFromSequence() async -> Bool {
@@ -318,9 +316,6 @@ class VideoPlayerViewModel {
         playlist.onPlayEnd = { [weak self] in
             guard self?.playMode == .regular else { return }
             self?.onExit?()
-        }
-        playlist.onPlayPreviousWithInfo = { [weak self] info in
-            self?.updatePlayInfo(info)
         }
         playlist.onPlayNextWithInfo = {
             [weak self] info in

--- a/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
@@ -40,7 +40,7 @@ class VideoPlayerViewModel {
     private let mediaWarmupManager: PlayerMediaWarmupManager?
     private let previewMuted: Bool
     private let startTimeOverride: Int?
-    private let startTimeOverrideSequenceKey: String
+    private let startTimeOverrideContentIdentity: String
     private var videoDetail: VideoDetail?
     private var cancellable = Set<AnyCancellable>()
     private var loadTask: Task<Void, Never>?
@@ -59,7 +59,7 @@ class VideoPlayerViewModel {
         self.mediaWarmupManager = mediaWarmupManager
         self.previewMuted = previewMuted
         self.startTimeOverride = startTimeOverride
-        startTimeOverrideSequenceKey = playInfo.sequenceKey
+        startTimeOverrideContentIdentity = playInfo.contentIdentity
     }
 
     var currentPlayInfo: PlayInfo {
@@ -68,6 +68,12 @@ class VideoPlayerViewModel {
 
     func load() async {
         await startLoad(for: playInfo).value
+    }
+
+    func cancelLoading() {
+        loadTask?.cancel()
+        loadTask = nil
+        loadGeneration += 1
     }
 
     @discardableResult
@@ -221,7 +227,7 @@ class VideoPlayerViewModel {
                                         playInfo: PlayInfo) -> Int?
     {
         if let startTimeOverride,
-           startTimeOverrideSequenceKey == playInfo.sequenceKey,
+           startTimeOverrideContentIdentity == playInfo.contentIdentity,
            duration - startTimeOverride > 5
         {
             return startTimeOverride
@@ -271,7 +277,6 @@ class VideoPlayerViewModel {
             await playContextCache.preload(playInfo: info, mode: .regular)
         }
         await playContextCache.trim(keeping: priority)
-        await mediaWarmupManager?.retain(playInfos: priority)
         for info in priority {
             await mediaWarmupManager?.preload(playInfo: info)
         }

--- a/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
@@ -26,8 +26,9 @@ struct PlayerDetailData {
     }
 }
 
+@MainActor
 class VideoPlayerViewModel {
-    var onPluginReady = PassthroughSubject<[CommonPlayerPlugin], String>()
+    let loadResult = PassthroughSubject<Result<[CommonPlayerPlugin], String>, Never>()
     var onExit: (() -> Void)?
     var onPlayInfoChanged: ((PlayInfo) -> Void)?
     var onShowDetail: ((PlayInfo) -> Void)?
@@ -40,10 +41,10 @@ class VideoPlayerViewModel {
     private let previewMuted: Bool
     private let startTimeOverride: Int?
     private let startTimeOverrideSequenceKey: String
-    private let danmuProvider = VideoDanmuProvider(enableDanmuFilter: Settings.enableDanmuFilter,
-                                                   enableDanmuRemoveDup: Settings.enableDanmuRemoveDup)
     private var videoDetail: VideoDetail?
     private var cancellable = Set<AnyCancellable>()
+    private var loadTask: Task<Void, Never>?
+    private var loadGeneration = 0
 
     init(playInfo: PlayInfo,
          playMode: VideoPlayerMode = .regular,
@@ -66,50 +67,80 @@ class VideoPlayerViewModel {
     }
 
     func load() async {
+        await startLoad(for: playInfo).value
+    }
+
+    @discardableResult
+    private func startLoad(for requestedPlayInfo: PlayInfo) -> Task<Void, Never> {
+        loadTask?.cancel()
+        loadGeneration += 1
+        let generation = loadGeneration
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await performLoad(for: requestedPlayInfo, generation: generation)
+        }
+        loadTask = task
+        return task
+    }
+
+    private func performLoad(for requestedPlayInfo: PlayInfo, generation: Int) async {
+        defer {
+            if loadGeneration == generation {
+                loadTask = nil
+            }
+        }
         do {
-            let data = try await loadVideoInfo()
-            guard !Task.isCancelled else { return }
-            let plugin = await generatePlayerPlugin(data)
-            guard !Task.isCancelled else { return }
-            onPluginReady.send(plugin)
+            let (resolvedPlayInfo, data) = try await loadVideoInfo(for: requestedPlayInfo)
+            guard !Task.isCancelled, loadGeneration == generation else { return }
+
+            let danmuProvider = VideoDanmuProvider(enableDanmuFilter: Settings.enableDanmuFilter,
+                                                   enableDanmuRemoveDup: Settings.enableDanmuRemoveDup)
+            await danmuProvider.initVideo(cid: data.cid, startPos: data.playerStartPos ?? 0)
+            guard !Task.isCancelled, loadGeneration == generation else { return }
+
+            playInfo = resolvedPlayInfo
+            videoDetail = data.detail
+            BiliBiliUpnpDMR.shared.sendVideoSwitch(aid: resolvedPlayInfo.aid, cid: data.cid)
+            cancellable.removeAll()
+            let plugins = generatePlayerPlugin(data,
+                                               playInfo: resolvedPlayInfo,
+                                               danmuProvider: danmuProvider)
+            guard !Task.isCancelled, loadGeneration == generation else { return }
+            loadResult.send(.success(plugins))
         } catch is CancellationError {
             return
         } catch let err {
-            guard !Task.isCancelled else { return }
-            onPluginReady.send(completion: .failure(err.localizedDescription))
+            guard !Task.isCancelled, loadGeneration == generation else { return }
+            loadResult.send(.failure(err.localizedDescription))
         }
     }
 
-    private func loadVideoInfo() async throws -> PlayerDetailData {
-        try await initPlayInfo()
-        let data = try await fetchVideoData()
-        await danmuProvider.initVideo(cid: data.cid, startPos: data.playerStartPos ?? 0)
-        return data
+    private func loadVideoInfo(for playInfo: PlayInfo) async throws -> (PlayInfo, PlayerDetailData) {
+        let resolvedPlayInfo = try await PlayInfoResolver.resolve(playInfo)
+        try Task.checkCancellation()
+        let data = try await fetchVideoData(for: resolvedPlayInfo)
+        try Task.checkCancellation()
+        return (resolvedPlayInfo, data)
     }
 
-    private func initPlayInfo() async throws {
-        playInfo = try await PlayInfoResolver.resolve(playInfo)
-        BiliBiliUpnpDMR.shared.sendVideoSwitch(aid: playInfo.aid, cid: playInfo.cid ?? 0)
+    private func fetchVideoDetail(aid: Int, existing: VideoDetail?) async -> VideoDetail? {
+        if let existing { return existing }
+        return try? await WebRequest.requestDetailVideo(aid: aid)
     }
 
-    private func updateVideoDetailIfNeeded() async {
-        if videoDetail == nil || videoDetail?.View.aid != playInfo.aid {
-            videoDetail = try? await WebRequest.requestDetailVideo(aid: playInfo.aid)
-        }
-    }
-
-    private func fetchVideoData() async throws -> PlayerDetailData {
+    private func fetchVideoData(for playInfo: PlayInfo) async throws -> PlayerDetailData {
         assert(playInfo.isCidVaild)
+        let existingVideoDetail = videoDetail?.View.aid == playInfo.aid ? videoDetail : nil
         if !playInfo.isBangumi, let playContextCache {
             let cached = try await playContextCache.context(for: playInfo, mode: playContextMode)
-            videoDetail = cached.detail ?? videoDetail
+            let resolvedDetail = cached.detail ?? existingVideoDetail
 
             var detail = PlayerDetailData(aid: playInfo.aid,
                                           cid: cached.cid,
                                           epid: playInfo.epid,
                                           seasonId: playInfo.seasonId,
                                           subType: playInfo.subType,
-                                          detail: cached.detail ?? videoDetail,
+                                          detail: resolvedDetail,
                                           clips: nil,
                                           playerInfo: cached.playerInfo,
                                           videoPlayURLInfo: cached.videoPlayURLInfo)
@@ -119,14 +150,15 @@ class VideoPlayerViewModel {
             detail.playerStartPos = resolvedPlayerStartPos(cid: cached.cid,
                                                            duration: cached.videoPlayURLInfo.dash.duration,
                                                            lastPlayCid: lastPlayCid,
-                                                           playTimeInSecond: playTimeInSecond)
+                                                           playTimeInSecond: playTimeInSecond,
+                                                           playInfo: playInfo)
             return detail
         }
 
         let aid = playInfo.aid
         let cid = playInfo.cid!
         async let infoReq = try? WebRequest.requestPlayerInfo(aid: aid, cid: cid)
-        async let detailUpdate: () = updateVideoDetailIfNeeded()
+        async let detailReq = fetchVideoDetail(aid: aid, existing: existingVideoDetail)
         do {
             let playData: VideoPlayURLInfo
             var clipInfos: [VideoPlayURLInfo.ClipInfo]?
@@ -137,7 +169,7 @@ class VideoPlayerViewModel {
                 } catch let err as RequestError {
                     if case let .statusFail(code, _) = err,
                        code == -404 || code == -10403,
-                       let data = try await fetchAreaLimitPcgVideoData()
+                       let data = try await fetchAreaLimitPcgVideoData(for: playInfo)
                     {
                         playData = data
                     } else {
@@ -151,16 +183,17 @@ class VideoPlayerViewModel {
             }
 
             let info = await infoReq
-            _ = await detailUpdate
+            let resolvedDetail = await detailReq
 
-            var detail = PlayerDetailData(aid: playInfo.aid, cid: playInfo.cid!, epid: playInfo.epid, seasonId: playInfo.seasonId, subType: playInfo.subType, detail: videoDetail, clips: clipInfos, playerInfo: info, videoPlayURLInfo: playData)
+            var detail = PlayerDetailData(aid: playInfo.aid, cid: playInfo.cid!, epid: playInfo.epid, seasonId: playInfo.seasonId, subType: playInfo.subType, detail: resolvedDetail, clips: clipInfos, playerInfo: info, videoPlayURLInfo: playData)
 
             let last_play_cid = playInfo.lastPlayCid ?? info?.last_play_cid ?? 0
             let playTimeInSecond = playInfo.playTimeInSecond ?? info?.playTimeInSecond ?? 0
             detail.playerStartPos = resolvedPlayerStartPos(cid: cid,
                                                            duration: playData.dash.duration,
                                                            lastPlayCid: last_play_cid,
-                                                           playTimeInSecond: playTimeInSecond)
+                                                           playTimeInSecond: playTimeInSecond,
+                                                           playInfo: playInfo)
 
             return detail
 
@@ -178,15 +211,14 @@ class VideoPlayerViewModel {
     private func updatePlayInfo(_ newPlayInfo: PlayInfo) {
         playInfo = newPlayInfo
         onPlayInfoChanged?(newPlayInfo)
-        Task {
-            await load()
-        }
+        startLoad(for: newPlayInfo)
     }
 
     private func resolvedPlayerStartPos(cid: Int,
                                         duration: Int,
                                         lastPlayCid: Int,
-                                        playTimeInSecond: Int) -> Int?
+                                        playTimeInSecond: Int,
+                                        playInfo: PlayInfo) -> Int?
     {
         if let startTimeOverride,
            startTimeOverrideSequenceKey == playInfo.sequenceKey,
@@ -214,7 +246,7 @@ class VideoPlayerViewModel {
     }
 
     func playPreviousFromSequence() async -> Bool {
-        guard let previous = await sequenceProvider?.movePrevious() else { return false }
+        guard let previous = sequenceProvider?.movePrevious() else { return false }
         updatePlayInfo(previous)
         return true
     }
@@ -231,10 +263,10 @@ class VideoPlayerViewModel {
 
     func preloadNeighborsIfNeeded() async {
         guard playMode == .feedFlow, let playContextCache, let sequenceProvider else { return }
-        let current = await sequenceProvider.current() ?? currentPlayInfo
+        let current = sequenceProvider.current() ?? currentPlayInfo
         let priority = [current,
-                        await sequenceProvider.peekNext(),
-                        await sequenceProvider.peekPrevious()].compactMap { $0 }.uniqued()
+                        sequenceProvider.peekNext(),
+                        sequenceProvider.peekPrevious()].compactMap { $0 }.uniqued()
         for info in priority {
             await playContextCache.preload(playInfo: info, mode: .regular)
         }
@@ -245,13 +277,19 @@ class VideoPlayerViewModel {
         }
     }
 
-    @MainActor private func generatePlayerPlugin(_ data: PlayerDetailData) async -> [CommonPlayerPlugin] {
+    private func generatePlayerPlugin(_ data: PlayerDetailData,
+                                      playInfo: PlayInfo,
+                                      danmuProvider: VideoDanmuProvider) -> [CommonPlayerPlugin]
+    {
         let playplugin = BVideoPlayPlugin(playInfo: playInfo,
                                           detailData: data,
                                           reportWatchHistory: playMode != .preview,
                                           minimizeStalling: true,
                                           isMuted: playMode == .preview && previewMuted,
                                           mediaWarmupManager: playMode == .feedFlow ? mediaWarmupManager : nil)
+        playplugin.onLoadFailure = { [weak self] message in
+            self?.loadResult.send(.failure(message))
+        }
 
         if playMode == .preview {
             return [playplugin]
@@ -351,7 +389,7 @@ class VideoPlayerViewModel {
 
 // 港澳台解锁
 extension VideoPlayerViewModel {
-    private func fetchAreaLimitPcgVideoData() async throws -> VideoPlayURLInfo? {
+    private func fetchAreaLimitPcgVideoData(for playInfo: PlayInfo) async throws -> VideoPlayURLInfo? {
         guard Settings.areaLimitUnlock else { return nil }
         guard let epid = playInfo.epid, epid > 0 else { return nil }
 

--- a/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
@@ -274,10 +274,13 @@ class VideoPlayerViewModel {
                         sequenceProvider.peekNext(),
                         sequenceProvider.peekPrevious()].compactMap { $0 }.uniqued()
         for info in priority {
+            guard !Task.isCancelled else { return }
             await playContextCache.preload(playInfo: info, mode: .regular)
         }
+        guard !Task.isCancelled else { return }
         await playContextCache.trim(keeping: priority)
         for info in priority {
+            guard !Task.isCancelled else { return }
             await mediaWarmupManager?.preload(playInfo: info)
         }
     }

--- a/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
+++ b/BilibiliLive/Component/Video/VideoPlayerViewModel.swift
@@ -29,24 +29,53 @@ struct PlayerDetailData {
 class VideoPlayerViewModel {
     var onPluginReady = PassthroughSubject<[CommonPlayerPlugin], String>()
     var onExit: (() -> Void)?
-    var nextProvider: VideoNextProvider?
+    var onPlayInfoChanged: ((PlayInfo) -> Void)?
+    var onShowDetail: ((PlayInfo) -> Void)?
+    var sequenceProvider: VideoSequenceProvider?
 
     private var playInfo: PlayInfo
+    private let playMode: VideoPlayerMode
+    private let playContextCache: PlayContextCache?
+    private let mediaWarmupManager: PlayerMediaWarmupManager?
+    private let previewMuted: Bool
+    private let startTimeOverride: Int?
+    private let startTimeOverrideSequenceKey: String
     private let danmuProvider = VideoDanmuProvider(enableDanmuFilter: Settings.enableDanmuFilter,
                                                    enableDanmuRemoveDup: Settings.enableDanmuRemoveDup)
     private var videoDetail: VideoDetail?
     private var cancellable = Set<AnyCancellable>()
 
-    init(playInfo: PlayInfo) {
+    init(playInfo: PlayInfo,
+         playMode: VideoPlayerMode = .regular,
+         playContextCache: PlayContextCache? = nil,
+         mediaWarmupManager: PlayerMediaWarmupManager? = nil,
+         previewMuted: Bool = true,
+         startTimeOverride: Int? = nil)
+    {
         self.playInfo = playInfo
+        self.playMode = playMode
+        self.playContextCache = playContextCache
+        self.mediaWarmupManager = mediaWarmupManager
+        self.previewMuted = previewMuted
+        self.startTimeOverride = startTimeOverride
+        startTimeOverrideSequenceKey = playInfo.sequenceKey
+    }
+
+    var currentPlayInfo: PlayInfo {
+        playInfo
     }
 
     func load() async {
         do {
             let data = try await loadVideoInfo()
+            guard !Task.isCancelled else { return }
             let plugin = await generatePlayerPlugin(data)
+            guard !Task.isCancelled else { return }
             onPluginReady.send(plugin)
+        } catch is CancellationError {
+            return
         } catch let err {
+            guard !Task.isCancelled else { return }
             onPluginReady.send(completion: .failure(err.localizedDescription))
         }
     }
@@ -59,9 +88,7 @@ class VideoPlayerViewModel {
     }
 
     private func initPlayInfo() async throws {
-        if !playInfo.isCidVaild {
-            playInfo.cid = try await WebRequest.requestCid(aid: playInfo.aid)
-        }
+        playInfo = try await PlayInfoResolver.resolve(playInfo)
         BiliBiliUpnpDMR.shared.sendVideoSwitch(aid: playInfo.aid, cid: playInfo.cid ?? 0)
     }
 
@@ -73,6 +100,29 @@ class VideoPlayerViewModel {
 
     private func fetchVideoData() async throws -> PlayerDetailData {
         assert(playInfo.isCidVaild)
+        if !playInfo.isBangumi, let playContextCache {
+            let cached = try await playContextCache.context(for: playInfo, mode: playContextMode)
+            videoDetail = cached.detail ?? videoDetail
+
+            var detail = PlayerDetailData(aid: playInfo.aid,
+                                          cid: cached.cid,
+                                          epid: playInfo.epid,
+                                          seasonId: playInfo.seasonId,
+                                          subType: playInfo.subType,
+                                          detail: cached.detail ?? videoDetail,
+                                          clips: nil,
+                                          playerInfo: cached.playerInfo,
+                                          videoPlayURLInfo: cached.videoPlayURLInfo)
+
+            let lastPlayCid = playInfo.lastPlayCid ?? cached.playerInfo?.last_play_cid ?? 0
+            let playTimeInSecond = playInfo.playTimeInSecond ?? cached.playerInfo?.playTimeInSecond ?? 0
+            detail.playerStartPos = resolvedPlayerStartPos(cid: cached.cid,
+                                                           duration: cached.videoPlayURLInfo.dash.duration,
+                                                           lastPlayCid: lastPlayCid,
+                                                           playTimeInSecond: playTimeInSecond)
+            return detail
+        }
+
         let aid = playInfo.aid
         let cid = playInfo.cid!
         async let infoReq = try? WebRequest.requestPlayerInfo(aid: aid, cid: cid)
@@ -83,7 +133,7 @@ class VideoPlayerViewModel {
 
             if playInfo.isBangumi {
                 do {
-                    playData = try await WebRequest.requestPcgPlayUrl(aid: aid, cid: cid)
+                    playData = try await WebRequest.requestPcgPlayUrl(aid: aid, cid: cid, options: playContextMode.requestOptions)
                 } catch let err as RequestError {
                     if case let .statusFail(code, _) = err,
                        code == -404 || code == -10403,
@@ -97,7 +147,7 @@ class VideoPlayerViewModel {
 
                 clipInfos = playData.clip_info_list
             } else {
-                playData = try await WebRequest.requestPlayUrl(aid: aid, cid: cid)
+                playData = try await WebRequest.requestPlayUrl(aid: aid, cid: cid, options: playContextMode.requestOptions)
             }
 
             let info = await infoReq
@@ -107,9 +157,10 @@ class VideoPlayerViewModel {
 
             let last_play_cid = playInfo.lastPlayCid ?? info?.last_play_cid ?? 0
             let playTimeInSecond = playInfo.playTimeInSecond ?? info?.playTimeInSecond ?? 0
-            if last_play_cid == cid, playData.dash.duration - playTimeInSecond > 5, Settings.continuePlay {
-                detail.playerStartPos = playTimeInSecond
-            }
+            detail.playerStartPos = resolvedPlayerStartPos(cid: cid,
+                                                           duration: playData.dash.duration,
+                                                           lastPlayCid: last_play_cid,
+                                                           playTimeInSecond: playTimeInSecond)
 
             return detail
 
@@ -124,15 +175,88 @@ class VideoPlayerViewModel {
         }
     }
 
-    private func playNext(newPlayInfo: PlayInfo) {
+    private func updatePlayInfo(_ newPlayInfo: PlayInfo) {
         playInfo = newPlayInfo
+        onPlayInfoChanged?(newPlayInfo)
         Task {
             await load()
         }
     }
 
+    private func resolvedPlayerStartPos(cid: Int,
+                                        duration: Int,
+                                        lastPlayCid: Int,
+                                        playTimeInSecond: Int) -> Int?
+    {
+        if let startTimeOverride,
+           startTimeOverrideSequenceKey == playInfo.sequenceKey,
+           duration - startTimeOverride > 5
+        {
+            return startTimeOverride
+        }
+        if lastPlayCid == cid,
+           duration - playTimeInSecond > 5,
+           Settings.continuePlay
+        {
+            return playTimeInSecond
+        }
+        return nil
+    }
+
+    func retryCurrent() async {
+        await load()
+    }
+
+    func playNextFromSequence() async -> Bool {
+        guard let next = await sequenceProvider?.moveNext() else { return false }
+        updatePlayInfo(next)
+        return true
+    }
+
+    func playPreviousFromSequence() async -> Bool {
+        guard let previous = await sequenceProvider?.movePrevious() else { return false }
+        updatePlayInfo(previous)
+        return true
+    }
+
+    func playTemporaryOverride(_ temporaryPlayInfo: PlayInfo) {
+        guard temporaryPlayInfo.sequenceKey != currentPlayInfo.sequenceKey else { return }
+        sequenceProvider.map { provider in
+            MainActor.assumeIsolated {
+                provider.pushTemporary(temporaryPlayInfo)
+            }
+        }
+        updatePlayInfo(temporaryPlayInfo)
+    }
+
+    func preloadNeighborsIfNeeded() async {
+        guard playMode == .feedFlow, let playContextCache, let sequenceProvider else { return }
+        let current = await sequenceProvider.current() ?? currentPlayInfo
+        let priority = [current,
+                        await sequenceProvider.peekNext(),
+                        await sequenceProvider.peekPrevious()].compactMap { $0 }.uniqued()
+        for info in priority {
+            await playContextCache.preload(playInfo: info, mode: .regular)
+        }
+        await playContextCache.trim(keeping: priority)
+        await mediaWarmupManager?.retain(playInfos: priority)
+        for info in priority {
+            await mediaWarmupManager?.preload(playInfo: info)
+        }
+    }
+
     @MainActor private func generatePlayerPlugin(_ data: PlayerDetailData) async -> [CommonPlayerPlugin] {
-        let playplugin = BVideoPlayPlugin(detailData: data)
+        let playplugin = BVideoPlayPlugin(playInfo: playInfo,
+                                          detailData: data,
+                                          reportWatchHistory: playMode != .preview,
+                                          minimizeStalling: true,
+                                          isMuted: playMode == .preview && previewMuted,
+                                          mediaWarmupManager: playMode == .feedFlow ? mediaWarmupManager : nil)
+
+        if playMode == .preview {
+            return [playplugin]
+        }
+
         let danmu = DanmuViewPlugin(provider: danmuProvider)
         let upnp = BUpnpPlugin(duration: data.detail?.View.duration)
         let debug = DebugPlugin()
@@ -144,15 +268,25 @@ class VideoPlayerViewModel {
             danmu?.danMuView.playingSpeed = speed.value
         }.store(in: &cancellable)
 
-        let playlist = VideoPlayListPlugin(nextProvider: nextProvider)
+        let playlist = VideoPlayListPlugin(sequenceProvider: sequenceProvider)
         playlist.onPlayEnd = { [weak self] in
+            guard self?.playMode == .regular else { return }
             self?.onExit?()
+        }
+        playlist.onPlayPreviousWithInfo = { [weak self] info in
+            self?.updatePlayInfo(info)
         }
         playlist.onPlayNextWithInfo = {
             [weak self] info in
             guard let self else { return }
-            playNext(newPlayInfo: info)
+            updatePlayInfo(info)
         }
+        playlist.onShowCurrentDetail = { [weak self] info in
+            self?.onShowDetail?(info)
+        }
+
+        // SpeedChangerPlugin creates the shared settings menu that later plugins extend.
+        var plugins: [CommonPlayerPlugin] = [playSpeed, playplugin, danmu, upnp, debug, playlist]
 
         // 添加画质选择器插件
         let qualitySelector = BVideoQualityPlugin(detailData: data) { [weak playplugin] qualityId, streamIndex in
@@ -161,8 +295,7 @@ class VideoPlayerViewModel {
             }
         }
 
-        // playSpeed 先创建 identifier=setting 的「播放设置」菜单，后续插件（CDN 测速、Debug 等）才能挂进去
-        var plugins: [CommonPlayerPlugin] = [playSpeed, playplugin, danmu, upnp, debug, playlist, qualitySelector]
+        plugins.append(qualitySelector)
 
         if let clips = data.clips {
             let clip = BVideoClipsPlugin(clipInfos: clips)
@@ -205,6 +338,15 @@ class VideoPlayerViewModel {
 
         return plugins
     }
+
+    private var playContextMode: PlayContextMode {
+        switch playMode {
+        case .preview:
+            return .preview
+        case .regular, .feedFlow:
+            return .regular
+        }
+    }
 }
 
 // 港澳台解锁
@@ -225,7 +367,10 @@ extension VideoPlayerViewModel {
     private func requestAreaLimitPcgPlayUrl(epid: Int, cid: Int, areaList: [String]) async throws -> VideoPlayURLInfo? {
         for area in areaList {
             do {
-                return try await WebRequest.requestAreaLimitPcgPlayUrl(epid: epid, cid: cid, area: area)
+                return try await WebRequest.requestAreaLimitPcgPlayUrl(epid: epid,
+                                                                       cid: cid,
+                                                                       area: area,
+                                                                       options: playContextMode.requestOptions)
             } catch let err {
                 if area == areaList.last {
                     throw err

--- a/BilibiliLive/Extensions/AVInfoPanelCollectionViewThumbnailCell+Hook.swift
+++ b/BilibiliLive/Extensions/AVInfoPanelCollectionViewThumbnailCell+Hook.swift
@@ -6,40 +6,174 @@
 //
 
 import Foundation
+import ObjectiveC
 import UIKit
 
 class AVInfoPanelCollectionViewThumbnailCellHook {
     static func start() {
-        UICollectionViewCell.swizzAVInfoPanelCollectionViewThumbnailCell()
+        UICollectionViewCell.startAVInfoPanelSwizzle()
     }
 }
 
+extension UICollectionViewCell {
+    static let infoActionFocusedNotification = Notification.Name("AVInfoPanelActionFocused")
+}
+
 private extension UICollectionViewCell {
+    private static var avInfoPanelActionTitleKey: UInt8 = 0
+    private static let infoPanelClassNameMarker = "AVInfoPanel"
+    private static var swizzledMethodKeys = Set<String>()
+
+    static func startAVInfoPanelSwizzle() {
+        swizzAVInfoPanelCollectionViewThumbnailCell()
+    }
+
     static func swizzAVInfoPanelCollectionViewThumbnailCell() {
-        let swizzledClass: AnyClass = NSClassFromString("AVInfoPanelCollectionViewThumbnailCell")!
-        let originalSelector = NSSelectorFromString("setTitle:")
+        let didUpdateFocusSelector = #selector(didUpdateFocus(in:with:))
+        let swizzledDidUpdateFocusSelector = #selector(swizz_didUpdateFocus(in:with:))
+        let setTitleSelector = NSSelectorFromString("setTitle:")
+        let swizzledSetTitleSelector = #selector(swizz_setTitle(_:))
 
-        let swizzledSelector = #selector(swizz_setTitle(_:))
-        let originalSelector2 = NSSelectorFromString("didUpdateFocusInContext:withAnimationCoordinator:")
-        let swizzledSelector2 = #selector(swizz_didUpdateFocusInContext(_:withAnimationCoordinator:))
+        for targetClass in avInfoPanelCellClasses() {
+            swizzleMethodIfNeeded(on: targetClass,
+                                  originalSelector: didUpdateFocusSelector,
+                                  swizzledSelector: swizzledDidUpdateFocusSelector)
+            swizzleMethodIfNeeded(on: targetClass,
+                                  originalSelector: setTitleSelector,
+                                  swizzledSelector: swizzledSetTitleSelector)
+        }
+    }
 
-        guard let originalMethod = class_getInstanceMethod(swizzledClass, originalSelector),
-              let swizzledMethod = class_getInstanceMethod(self, swizzledSelector),
-              let originalMethod2 = class_getInstanceMethod(swizzledClass, originalSelector2),
-              let swizzledMethod2 = class_getInstanceMethod(self, swizzledSelector2)
+    static func avInfoPanelCellClasses() -> [AnyClass] {
+        let expectedClassCount = Int(objc_getClassList(nil, 0))
+        guard expectedClassCount > 0 else { return [] }
 
+        let classBuffer = UnsafeMutablePointer<AnyClass?>.allocate(capacity: expectedClassCount)
+        defer { classBuffer.deallocate() }
+
+        let autoreleasingClassBuffer = AutoreleasingUnsafeMutablePointer<AnyClass>(classBuffer)
+        let actualClassCount = Int(objc_getClassList(autoreleasingClassBuffer, Int32(expectedClassCount)))
+
+        let matchedClasses = UnsafeBufferPointer(start: classBuffer, count: actualClassCount)
+            .compactMap { $0 }
+            .filter { targetClass in
+                let className = NSStringFromClass(targetClass)
+                return className.contains(infoPanelClassNameMarker) &&
+                    isSubclass(targetClass, of: UICollectionViewCell.self)
+            }
+
+        return matchedClasses
+            .filter { candidateClass in
+                !matchedClasses.contains { otherClass in
+                    otherClass !== candidateClass && isSubclass(otherClass, of: candidateClass)
+                }
+            }
+            .sorted { NSStringFromClass($0) < NSStringFromClass($1) }
+    }
+
+    static func isSubclass(_ targetClass: AnyClass, of parentClass: AnyClass) -> Bool {
+        var currentClass: AnyClass? = targetClass
+        while let candidateClass = currentClass {
+            if candidateClass == parentClass {
+                return true
+            }
+            currentClass = class_getSuperclass(candidateClass)
+        }
+        return false
+    }
+
+    static func swizzleMethodIfNeeded(on targetClass: AnyClass,
+                                      originalSelector: Selector,
+                                      swizzledSelector: Selector)
+    {
+        let swizzleKey = "\(NSStringFromClass(targetClass))::\(NSStringFromSelector(originalSelector))"
+        guard !swizzledMethodKeys.contains(swizzleKey) else { return }
+        guard let originalMethod = class_getInstanceMethod(targetClass, originalSelector),
+              let baseSwizzledMethod = class_getInstanceMethod(UICollectionViewCell.self, swizzledSelector)
         else { return }
-        method_exchangeImplementations(originalMethod, swizzledMethod)
-        method_exchangeImplementations(originalMethod2, swizzledMethod2)
+
+        class_addMethod(targetClass,
+                        swizzledSelector,
+                        method_getImplementation(baseSwizzledMethod),
+                        method_getTypeEncoding(baseSwizzledMethod))
+
+        guard let targetSwizzledMethod = class_getInstanceMethod(targetClass, swizzledSelector) else { return }
+
+        let didAddOriginalMethod = class_addMethod(targetClass,
+                                                   originalSelector,
+                                                   method_getImplementation(targetSwizzledMethod),
+                                                   method_getTypeEncoding(targetSwizzledMethod))
+
+        if didAddOriginalMethod {
+            class_replaceMethod(targetClass,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod))
+        } else {
+            method_exchangeImplementations(originalMethod, targetSwizzledMethod)
+        }
+
+        swizzledMethodKeys.insert(swizzleKey)
     }
 
     @objc func swizz_setTitle(_ title: String) {
+        // 调用原实现 (已被交换)
         swizz_setTitle(title)
+        avInfoPanelActionTitle = title
         contentView.subviews.compactMap { $0 as? UILabel }.forEach { $0.textColor = .white }
     }
 
-    @objc func swizz_didUpdateFocusInContext(_ selected: Any, withAnimationCoordinator: Any) {
-        swizz_didUpdateFocusInContext(selected, withAnimationCoordinator: withAnimationCoordinator)
-        contentView.subviews.compactMap { $0 as? UILabel }.forEach { $0.textColor = .white }
+    @objc func swizz_didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        // 调用原实现
+        swizz_didUpdateFocus(in: context, with: coordinator)
+
+        let className = NSStringFromClass(type(of: self))
+        guard className.contains("AVInfoPanel") else { return }
+
+        // 强制白色文字 (视觉一致性)
+        recursiveApplyWhiteText(to: self)
+
+        guard isFocused else { return }
+
+        // 尝试多种方式提取标题
+        let title = avInfoPanelActionTitle ??
+            accessibilityLabel ??
+            recursiveFindTitle(in: self)
+
+        if let title = title {
+            NotificationCenter.default.post(name: Self.infoActionFocusedNotification,
+                                            object: nil,
+                                            userInfo: ["title": title])
+        }
+    }
+
+    private func recursiveApplyWhiteText(to view: UIView) {
+        if let label = view as? UILabel {
+            label.textColor = .white
+        }
+        for subview in view.subviews {
+            recursiveApplyWhiteText(to: subview)
+        }
+    }
+
+    private func recursiveFindTitle(in view: UIView) -> String? {
+        if let label = view as? UILabel, let text = label.text, !text.isEmpty {
+            return text
+        }
+        for subview in view.subviews {
+            if let found = recursiveFindTitle(in: subview) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    var avInfoPanelActionTitle: String? {
+        get {
+            objc_getAssociatedObject(self, &Self.avInfoPanelActionTitleKey) as? String
+        }
+        set {
+            objc_setAssociatedObject(self, &Self.avInfoPanelActionTitleKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+        }
     }
 }

--- a/BilibiliLive/Extensions/AVInfoPanelCollectionViewThumbnailCell+Hook.swift
+++ b/BilibiliLive/Extensions/AVInfoPanelCollectionViewThumbnailCell+Hook.swift
@@ -10,7 +10,8 @@ import ObjectiveC
 import UIKit
 
 class AVInfoPanelCollectionViewThumbnailCellHook {
-    static func start() {
+    @discardableResult
+    static func start() -> Bool {
         UICollectionViewCell.startAVInfoPanelSwizzle()
     }
 }
@@ -24,24 +25,29 @@ private extension UICollectionViewCell {
     private static let infoPanelClassNameMarker = "AVInfoPanel"
     private static var swizzledMethodKeys = Set<String>()
 
-    static func startAVInfoPanelSwizzle() {
+    static func startAVInfoPanelSwizzle() -> Bool {
         swizzAVInfoPanelCollectionViewThumbnailCell()
     }
 
-    static func swizzAVInfoPanelCollectionViewThumbnailCell() {
+    static func swizzAVInfoPanelCollectionViewThumbnailCell() -> Bool {
         let didUpdateFocusSelector = #selector(didUpdateFocus(in:with:))
         let swizzledDidUpdateFocusSelector = #selector(swizz_didUpdateFocus(in:with:))
         let setTitleSelector = NSSelectorFromString("setTitle:")
         let swizzledSetTitleSelector = #selector(swizz_setTitle(_:))
+        var installedFocusHook = false
 
         for targetClass in avInfoPanelCellClasses() {
-            swizzleMethodIfNeeded(on: targetClass,
-                                  originalSelector: didUpdateFocusSelector,
-                                  swizzledSelector: swizzledDidUpdateFocusSelector)
-            swizzleMethodIfNeeded(on: targetClass,
-                                  originalSelector: setTitleSelector,
-                                  swizzledSelector: swizzledSetTitleSelector)
+            if swizzleMethodIfNeeded(on: targetClass,
+                                     originalSelector: didUpdateFocusSelector,
+                                     swizzledSelector: swizzledDidUpdateFocusSelector)
+            {
+                installedFocusHook = true
+            }
+            _ = swizzleMethodIfNeeded(on: targetClass,
+                                      originalSelector: setTitleSelector,
+                                      swizzledSelector: swizzledSetTitleSelector)
         }
+        return installedFocusHook
     }
 
     static func avInfoPanelCellClasses() -> [AnyClass] {
@@ -84,20 +90,20 @@ private extension UICollectionViewCell {
 
     static func swizzleMethodIfNeeded(on targetClass: AnyClass,
                                       originalSelector: Selector,
-                                      swizzledSelector: Selector)
+                                      swizzledSelector: Selector) -> Bool
     {
         let swizzleKey = "\(NSStringFromClass(targetClass))::\(NSStringFromSelector(originalSelector))"
-        guard !swizzledMethodKeys.contains(swizzleKey) else { return }
+        guard !swizzledMethodKeys.contains(swizzleKey) else { return false }
         guard let originalMethod = class_getInstanceMethod(targetClass, originalSelector),
               let baseSwizzledMethod = class_getInstanceMethod(UICollectionViewCell.self, swizzledSelector)
-        else { return }
+        else { return false }
 
         class_addMethod(targetClass,
                         swizzledSelector,
                         method_getImplementation(baseSwizzledMethod),
                         method_getTypeEncoding(baseSwizzledMethod))
 
-        guard let targetSwizzledMethod = class_getInstanceMethod(targetClass, swizzledSelector) else { return }
+        guard let targetSwizzledMethod = class_getInstanceMethod(targetClass, swizzledSelector) else { return false }
 
         let didAddOriginalMethod = class_addMethod(targetClass,
                                                    originalSelector,
@@ -114,6 +120,7 @@ private extension UICollectionViewCell {
         }
 
         swizzledMethodKeys.insert(swizzleKey)
+        return true
     }
 
     @objc func swizz_setTitle(_ title: String) {

--- a/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
@@ -592,7 +592,6 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
     private func warmupPlaybackMedia(for item: FeedFlowItem) async {
         let warmupInfos = prioritizedPlaybackWarmupInfos(for: item)
         await playContextCache.trim(keeping: warmupInfos)
-        await mediaWarmupManager.retain(playInfos: warmupInfos)
         for info in warmupInfos {
             await playContextCache.preload(playInfo: info, mode: .regular)
             await mediaWarmupManager.preload(playInfo: info)

--- a/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
@@ -16,6 +16,7 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
     private var focusedIndex = 0
     private var isLoading = false
     private var previewTask: Task<Void, Never>?
+    private var playbackWarmupTask: Task<Void, Never>?
     private var dataLoadTask: Task<Void, Never>?
     private var loadMoreTask: Task<[FeedFlowItem], Error>?
     private var loadGeneration = 0
@@ -163,6 +164,7 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
     deinit {
         NotificationCenter.default.removeObserver(self)
         previewTask?.cancel()
+        playbackWarmupTask?.cancel()
         dataLoadTask?.cancel()
         loadMoreTask?.cancel()
     }
@@ -466,6 +468,7 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
 
     private func schedulePreview(for item: FeedFlowItem) {
         previewTask?.cancel()
+        playbackWarmupTask?.cancel()
         Task { [mediaWarmupManager] in
             await mediaWarmupManager.cancelAll()
         }
@@ -514,7 +517,8 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
         controller.onPlaybackStarted = { [weak self, weak controller] in
             guard let self, let controller, self.previewController === controller else { return }
             self.revealPreviewPlaybackStarted(controller: controller)
-            Task { [weak self] in
+            self.playbackWarmupTask?.cancel()
+            self.playbackWarmupTask = Task { [weak self] in
                 await self?.warmupPlaybackMedia(for: item)
             }
         }
@@ -546,6 +550,8 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
         removePreviewController()
         restorePreviewPlaceholder(animated: false)
         if cancelWarmups {
+            playbackWarmupTask?.cancel()
+            playbackWarmupTask = nil
             Task { [mediaWarmupManager] in
                 await mediaWarmupManager.cancelAll()
             }
@@ -593,7 +599,9 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
         let warmupInfos = prioritizedPlaybackWarmupInfos(for: item)
         await playContextCache.trim(keeping: warmupInfos)
         for info in warmupInfos {
+            guard !Task.isCancelled else { return }
             await playContextCache.preload(playInfo: info, mode: .regular)
+            guard !Task.isCancelled else { return }
             await mediaWarmupManager.preload(playInfo: info)
         }
     }

--- a/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
@@ -1,0 +1,765 @@
+//
+//  FeedFlowBrowserViewController.swift
+//  BilibiliLive
+//
+//  Created by OpenAI on 2026/4/6.
+//
+
+import SnapKit
+import UIKit
+
+class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol {
+    private let preloadDelayNs: UInt64 = 1_000_000_000
+    private let dataSource: FeedFlowDataSource
+
+    private var items = [FeedFlowItem]()
+    private var focusedIndex = 0
+    private var isLoading = false
+    private var previewTask: Task<Void, Never>?
+    private var dataLoadTask: Task<Void, Never>?
+    private var loadMoreTask: Task<[FeedFlowItem], Error>?
+    private var loadGeneration = 0
+    private let playContextCache = PlayContextCache()
+    private lazy var mediaWarmupManager = PlayerMediaWarmupManager(playContextCache: playContextCache)
+    private lazy var sequenceProvider = VideoSequenceProvider(seq: [])
+    private var lastPlayedItemIdentity: String?
+    private var isPresentingFeedFlow = false
+    private var activeReloadToken = ""
+    private var lastReloadDate = Date.distantPast
+
+    private var previewController: VideoPlayerViewController?
+
+    private lazy var listCollectionView: UICollectionView = {
+        let layout = UICollectionViewCompositionalLayout { _, _ in
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(132))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(132))
+            let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = 16
+            section.contentInsets = NSDirectionalEdgeInsets(top: 24, leading: 0, bottom: 24, trailing: 20)
+            return section
+        }
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.remembersLastFocusedIndexPath = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.clipsToBounds = false
+        collectionView.allowsSelection = true
+        collectionView.register(FeedFlowListCell.self, forCellWithReuseIdentifier: FeedFlowListCell.reuseID)
+        return collectionView
+    }()
+
+    private let listTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 42, weight: .bold)
+        label.textColor = .white
+        return label
+    }()
+
+    private let previewHostView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black
+        view.clipsToBounds = true
+        return view
+    }()
+
+    private let previewPlaceholderView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        return iv
+    }()
+
+    private let previewLoadingView = UIActivityIndicatorView(style: .large)
+
+    private let leftGradientScrimView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let bottomGradientScrimView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let infoOverlayView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+
+    private let previewTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 44, weight: .bold)
+        label.textColor = .white
+        label.numberOfLines = 2
+        return label
+    }()
+
+    private let previewMetaLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 28, weight: .medium)
+        label.textColor = UIColor.white.withAlphaComponent(0.85)
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let previewHintLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 24, weight: .medium)
+        label.textColor = UIColor.white.withAlphaComponent(0.72)
+        label.numberOfLines = 2
+        return label
+    }()
+
+    private let emptyStateLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 30, weight: .medium)
+        label.textColor = UIColor.white.withAlphaComponent(0.72)
+        label.numberOfLines = 2
+        label.textAlignment = .center
+        label.isHidden = true
+        return label
+    }()
+
+    init(dataSource: FeedFlowDataSource) {
+        self.dataSource = dataSource
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var preferredFocusEnvironments: [UIFocusEnvironment] {
+        [listCollectionView]
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        restoresFocusAfterTransition = false
+        view.backgroundColor = .black
+        setupUI()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleAppWillResignActive),
+                                               name: UIApplication.willResignActiveNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleAppDidBecomeActive),
+                                               name: UIApplication.didBecomeActiveNotification,
+                                               object: nil)
+        sequenceProvider.onNeedMore = { [weak self] in
+            await self?.loadMoreItemsIfNeeded(targetCount: self?.dataSource.trailingPrefetchTargetCount ?? 8,
+                                              maxSourcePages: self?.dataSource.trailingMaxSourcePages ?? 3)
+        }
+        reloadData()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        previewTask?.cancel()
+        dataLoadTask?.cancel()
+        loadMoreTask?.cancel()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if activeReloadToken != dataSource.reloadToken {
+            reloadData()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        suspendPreview(cancelWarmups: !isPresentingFeedFlow)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        isPresentingFeedFlow = false
+        guard !autoReloadIfNeeded() else { return }
+        syncSelectionFromSequenceProvider()
+        resumePreviewIfNeeded()
+    }
+
+    @objc private func handleAppWillResignActive() {
+        guard isViewLoaded, view.window != nil else { return }
+        suspendPreview(cancelWarmups: true)
+    }
+
+    @objc private func handleAppDidBecomeActive() {
+        guard isViewLoaded, view.window != nil else { return }
+        guard !autoReloadIfNeeded() else { return }
+        resumePreviewIfNeeded()
+    }
+
+    func reloadData() {
+        loadGeneration += 1
+        let generation = loadGeneration
+        dataLoadTask?.cancel()
+        loadMoreTask?.cancel()
+        loadMoreTask = nil
+        isLoading = false
+        lastReloadDate = Date()
+        activeReloadToken = dataSource.reloadToken
+        dataSource.reset()
+        suspendPreview(cancelWarmups: true)
+        items = []
+        focusedIndex = 0
+        lastPlayedItemIdentity = nil
+        configureSequenceProvider(with: [])
+        listTitleLabel.text = dataSource.title
+        listCollectionView.reloadData()
+        emptyStateLabel.isHidden = true
+        previewHintLabel.text = dataSource.defaultPreviewHintText
+
+        previewHintLabel.text = dataSource.loadingHintText
+        previewLoadingView.startAnimating()
+        dataLoadTask = Task { [weak self] in
+            await self?.refreshFromStart(generation: generation)
+        }
+    }
+
+    @discardableResult
+    private func autoReloadIfNeeded() -> Bool {
+        guard let reloadInterval = dataSource.autoReloadInterval else { return false }
+        guard Date().timeIntervalSince(lastReloadDate) > reloadInterval else { return false }
+        reloadData()
+        return true
+    }
+
+    @MainActor
+    private func loadMoreItemsIfNeeded(targetCount: Int, maxSourcePages: Int) async {
+        guard !isLoading else { return }
+        let generation = loadGeneration
+        let activeIndex = max(focusedIndex, sequenceProvider.currentIndex)
+        guard items.count < targetCount || items.count - activeIndex - 1 < dataSource.trailingPrefetchTargetCount else { return }
+        isLoading = true
+        defer {
+            if generation == loadGeneration {
+                isLoading = false
+                loadMoreTask = nil
+            }
+        }
+
+        do {
+            let task = Task { [dataSource] in
+                try await dataSource.loadMoreItems(targetCount: targetCount, maxSourcePages: maxSourcePages)
+            }
+            loadMoreTask = task
+            let appended = try await task.value
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            guard !appended.isEmpty else { return }
+            appendLoadedItems(appended)
+            await playContextCache.trim(keeping: sequenceProvider.neighborItems(radius: 2))
+        } catch {
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            previewLoadingView.stopAnimating()
+            emptyStateLabel.text = dataSource.loadFailureText
+            emptyStateLabel.isHidden = false
+            previewHintLabel.text = "\(error)"
+        }
+    }
+
+    private func configureSequenceProvider(with items: [FeedFlowItem]) {
+        sequenceProvider = VideoSequenceProvider(seq: items.map(\.playInfo))
+        sequenceProvider.onNeedMore = { [weak self] in
+            await self?.loadMoreItemsIfNeeded(targetCount: self?.dataSource.trailingPrefetchTargetCount ?? 8,
+                                              maxSourcePages: self?.dataSource.trailingMaxSourcePages ?? 3)
+        }
+    }
+
+    @MainActor
+    private func refreshFromStart(generation: Int) async {
+        do {
+            let refreshedItems = try await dataSource.refreshFromStart(targetCount: dataSource.initialTargetCount,
+                                                                       maxSourcePages: dataSource.initialMaxSourcePages)
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            if refreshedItems.isEmpty {
+                guard items.isEmpty else { return }
+                restoreEmptyState()
+                return
+            }
+            applyFreshItems(refreshedItems)
+        } catch {
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            if items.isEmpty {
+                previewLoadingView.stopAnimating()
+                emptyStateLabel.text = dataSource.loadFailureText
+                emptyStateLabel.isHidden = false
+                previewHintLabel.text = "\(error)"
+            }
+        }
+    }
+
+    @MainActor
+    private func applyFreshItems(_ refreshedItems: [FeedFlowItem]) {
+        items = refreshedItems
+        configureSequenceProvider(with: items)
+        previewLoadingView.stopAnimating()
+        emptyStateLabel.isHidden = true
+        listCollectionView.reloadData()
+        syncSelectionFromSequenceProvider()
+    }
+
+    @MainActor
+    private func restoreEmptyState() {
+        previewLoadingView.stopAnimating()
+        emptyStateLabel.text = dataSource.emptyStateText
+        emptyStateLabel.isHidden = false
+        previewHintLabel.text = dataSource.emptyHintText
+    }
+
+    @MainActor
+    private func appendLoadedItems(_ appended: [FeedFlowItem]) {
+        guard !appended.isEmpty else { return }
+        var seen = Set(items.map(\.identityKey))
+        let deduped = appended.filter { seen.insert($0.identityKey).inserted }
+        guard !deduped.isEmpty else { return }
+
+        let start = items.count
+        items.append(contentsOf: deduped)
+        sequenceProvider.append(deduped.map(\.playInfo))
+        let indexPaths = (start..<(start + deduped.count)).map { IndexPath(item: $0, section: 0) }
+        guard listCollectionView.numberOfItems(inSection: 0) == start else {
+            listCollectionView.reloadData()
+            return
+        }
+        listCollectionView.performBatchUpdates {
+            listCollectionView.insertItems(at: indexPaths)
+        }
+    }
+
+    private func setupUI() {
+        view.addSubview(previewHostView)
+        previewHostView.addSubview(previewPlaceholderView)
+        view.addSubview(previewLoadingView)
+
+        previewHostView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        previewPlaceholderView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        previewLoadingView.hidesWhenStopped = true
+        previewLoadingView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+
+        view.addSubview(leftGradientScrimView)
+        view.addSubview(bottomGradientScrimView)
+
+        leftGradientScrimView.snp.makeConstraints { make in
+            make.top.leading.bottom.equalToSuperview()
+            make.width.equalToSuperview().multipliedBy(0.5)
+        }
+
+        bottomGradientScrimView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.height.equalToSuperview().multipliedBy(0.35)
+        }
+
+        view.addSubview(listTitleLabel)
+        view.addSubview(listCollectionView)
+
+        listTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(12)
+            make.leading.equalToSuperview().offset(48)
+        }
+
+        listCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(listTitleLabel.snp.bottom).offset(18)
+            make.leading.equalToSuperview().offset(36)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-24)
+            make.width.equalTo(470)
+        }
+
+        view.addSubview(infoOverlayView)
+        infoOverlayView.addSubview(previewTitleLabel)
+        infoOverlayView.addSubview(previewMetaLabel)
+        infoOverlayView.addSubview(previewHintLabel)
+
+        infoOverlayView.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-60)
+            make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-40)
+            make.width.equalTo(500)
+        }
+
+        previewTitleLabel.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+
+        previewMetaLabel.snp.makeConstraints { make in
+            make.top.equalTo(previewTitleLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview()
+        }
+
+        previewHintLabel.snp.makeConstraints { make in
+            make.top.equalTo(previewMetaLabel.snp.bottom).offset(8)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+
+        view.addSubview(emptyStateLabel)
+        emptyStateLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(60)
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        installGradientLayers()
+    }
+
+    private func installGradientLayers() {
+        if leftGradientScrimView.layer.sublayers?.first(where: { $0 is CAGradientLayer }) == nil {
+            let leftGradient = CAGradientLayer()
+            leftGradient.colors = [UIColor.black.withAlphaComponent(0.35).cgColor,
+                                   UIColor.black.withAlphaComponent(0.0).cgColor]
+            leftGradient.startPoint = CGPoint(x: 0, y: 0.5)
+            leftGradient.endPoint = CGPoint(x: 1, y: 0.5)
+            leftGradientScrimView.layer.insertSublayer(leftGradient, at: 0)
+        }
+        if let leftGradient = leftGradientScrimView.layer.sublayers?.first as? CAGradientLayer {
+            leftGradient.frame = leftGradientScrimView.bounds
+        }
+
+        if bottomGradientScrimView.layer.sublayers?.first(where: { $0 is CAGradientLayer }) == nil {
+            let bottomGradient = CAGradientLayer()
+            bottomGradient.colors = [UIColor.black.withAlphaComponent(0.0).cgColor,
+                                     UIColor.black.withAlphaComponent(0.55).cgColor]
+            bottomGradient.startPoint = CGPoint(x: 0.5, y: 0)
+            bottomGradient.endPoint = CGPoint(x: 0.5, y: 1)
+            bottomGradientScrimView.layer.insertSublayer(bottomGradient, at: 0)
+        }
+        if let bottomGradient = bottomGradientScrimView.layer.sublayers?.first as? CAGradientLayer {
+            bottomGradient.frame = bottomGradientScrimView.bounds
+        }
+    }
+
+    private func restorePreviewPlaceholder(animated: Bool) {
+        let animations = {
+            self.previewPlaceholderView.alpha = 1
+            self.previewController?.view.alpha = 0
+        }
+        if animated {
+            UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseInOut, animations: animations)
+        } else {
+            animations()
+        }
+    }
+
+    private func revealPreviewPlaybackStarted(controller: VideoPlayerViewController) {
+        previewLoadingView.stopAnimating()
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+            controller.view.alpha = 1
+            self.previewPlaceholderView.alpha = 0
+        }
+    }
+
+    private func schedulePreview(for item: FeedFlowItem) {
+        previewTask?.cancel()
+        Task { [mediaWarmupManager] in
+            await mediaWarmupManager.cancelAll()
+        }
+        removePreviewController()
+        restorePreviewPlaceholder(animated: false)
+        updatePreviewTexts(with: item)
+        previewLoadingView.startAnimating()
+        emptyStateLabel.isHidden = true
+        previewTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: preloadDelayNs)
+            guard !Task.isCancelled else { return }
+            await playContextCache.preload(playInfo: item.playInfo, mode: .preview)
+            let neighboringItems = self.neighborPlayInfos(around: self.focusedIndex)
+            for neighbor in neighboringItems {
+                await playContextCache.preload(playInfo: neighbor, mode: .preview)
+            }
+            await playContextCache.trim(keeping: neighboringItems)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                guard !Task.isCancelled,
+                      self.presentedViewController == nil,
+                      self.isViewLoaded,
+                      self.view.window != nil
+                else { return }
+                guard self.items.indices.contains(self.focusedIndex),
+                      self.items[self.focusedIndex] == item
+                else { return }
+                self.installPreviewController(for: item)
+            }
+        }
+    }
+
+    private func installPreviewController(for item: FeedFlowItem) {
+        removePreviewController()
+        let controller = VideoPlayerViewController(playInfo: item.playInfo,
+                                                   playMode: .preview,
+                                                   playContextCache: playContextCache,
+                                                   previewMuted: false)
+        controller.onLoadFailure = { [weak self, weak controller] _ in
+            guard let self, let controller, self.previewController === controller else { return }
+            self.previewLoadingView.stopAnimating()
+            self.previewHintLabel.text = "预览加载失败，按确认键可直接进入播放"
+            self.restorePreviewPlaceholder(animated: false)
+        }
+        controller.onPlaybackStarted = { [weak self, weak controller] in
+            guard let self, let controller, self.previewController === controller else { return }
+            self.revealPreviewPlaybackStarted(controller: controller)
+            Task { [weak self] in
+                await self?.warmupPlaybackMedia(for: item)
+            }
+        }
+        addChild(controller)
+        controller.view.alpha = 0
+        previewHostView.addSubview(controller.view)
+        controller.view.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        controller.didMove(toParent: self)
+        controller.view.isUserInteractionEnabled = false
+        previewController = controller
+    }
+
+    private func removePreviewController() {
+        previewController?.onPlaybackStarted = nil
+        previewController?.onLoadFailure = nil
+        previewController?.stopPlayback()
+        previewController?.willMove(toParent: nil)
+        previewController?.view.removeFromSuperview()
+        previewController?.removeFromParent()
+        previewController = nil
+    }
+
+    private func suspendPreview(cancelWarmups: Bool = true) {
+        previewTask?.cancel()
+        previewTask = nil
+        previewLoadingView.stopAnimating()
+        removePreviewController()
+        restorePreviewPlaceholder(animated: false)
+        if cancelWarmups {
+            Task { [mediaWarmupManager] in
+                await mediaWarmupManager.cancelAll()
+            }
+        }
+    }
+
+    private func updatePreviewTexts(with item: FeedFlowItem) {
+        previewTitleLabel.text = item.title
+        previewMetaLabel.text = item.metaText
+        previewHintLabel.text = item.reasonText?.isEmpty == false
+            ? "\(item.reasonText ?? "") · \(dataSource.defaultPreviewHintText)"
+            : dataSource.defaultPreviewHintText
+        if let coverURL = item.coverURL {
+            UIView.transition(with: previewPlaceholderView, duration: 0.25, options: .transitionCrossDissolve) {
+                self.previewPlaceholderView.kf.setImage(with: coverURL)
+            }
+        } else {
+            UIView.transition(with: previewPlaceholderView, duration: 0.25, options: .transitionCrossDissolve) {
+                self.previewPlaceholderView.image = nil
+            }
+        }
+    }
+
+    private func neighborPlayInfos(around index: Int) -> [PlayInfo] {
+        let lower = max(0, index - 1)
+        let upper = min(items.count - 1, index + 1)
+        guard !items.isEmpty, lower <= upper else { return [] }
+        return Array(items[lower...upper]).map(\.playInfo)
+    }
+
+    private func prioritizedPlaybackWarmupInfos(for item: FeedFlowItem) -> [PlayInfo] {
+        guard let index = items.firstIndex(of: item) else { return [item.playInfo] }
+        var warmupInfos = [PlayInfo]()
+        warmupInfos.append(items[index].playInfo)
+        if items.indices.contains(index + 1) {
+            warmupInfos.append(items[index + 1].playInfo)
+        }
+        if items.indices.contains(index - 1) {
+            warmupInfos.append(items[index - 1].playInfo)
+        }
+        return warmupInfos.uniqued()
+    }
+
+    private func warmupPlaybackMedia(for item: FeedFlowItem) async {
+        let warmupInfos = prioritizedPlaybackWarmupInfos(for: item)
+        await playContextCache.trim(keeping: warmupInfos)
+        await mediaWarmupManager.retain(playInfos: warmupInfos)
+        for info in warmupInfos {
+            await playContextCache.preload(playInfo: info, mode: .regular)
+            await mediaWarmupManager.preload(playInfo: info)
+        }
+    }
+
+    private func resolvedSelectionIndex() -> Int? {
+        guard !items.isEmpty else { return nil }
+        if let lastPlayedItemIdentity,
+           let matchedIndex = items.firstIndex(where: { $0.identityKey == lastPlayedItemIdentity })
+        {
+            return matchedIndex
+        }
+        return min(sequenceProvider.currentIndex, items.count - 1)
+    }
+
+    private func ensureListCollectionViewIsSynced() {
+        guard listCollectionView.numberOfItems(inSection: 0) != items.count else { return }
+        listCollectionView.reloadData()
+        listCollectionView.layoutIfNeeded()
+    }
+
+    private func refreshVisibleListCells() {
+        listCollectionView.visibleCells.compactMap { $0 as? FeedFlowListCell }.forEach { cell in
+            guard let indexPath = listCollectionView.indexPath(for: cell),
+                  items.indices.contains(indexPath.item)
+            else { return }
+            cell.configure(with: items[indexPath.item], isCurrent: indexPath.item == focusedIndex)
+        }
+    }
+
+    private func updateSelectionFromPlayInfo(_ playInfo: PlayInfo) {
+        let identityKey = FeedFlowItem.identityKey(for: playInfo)
+        lastPlayedItemIdentity = identityKey
+        guard let matchedIndex = items.firstIndex(where: { $0.identityKey == identityKey }) else { return }
+        focusedIndex = matchedIndex
+        sequenceProvider.setCurrentIndex(matchedIndex)
+    }
+
+    private func applyReturnedPlaybackSelection(_ playInfo: PlayInfo) {
+        updateSelectionFromPlayInfo(playInfo)
+        guard isViewLoaded, view.window != nil, presentedViewController == nil else { return }
+        syncSelectionFromSequenceProvider()
+    }
+
+    private func syncSelectionFromSequenceProvider() {
+        guard let targetIndex = resolvedSelectionIndex() else { return }
+        ensureListCollectionViewIsSynced()
+        guard listCollectionView.numberOfItems(inSection: 0) > targetIndex else { return }
+        focusedIndex = targetIndex
+        sequenceProvider.setCurrentIndex(targetIndex)
+        let targetIndexPath = IndexPath(item: targetIndex, section: 0)
+        listCollectionView.selectItem(at: targetIndexPath, animated: false, scrollPosition: .centeredVertically)
+        listCollectionView.scrollToItem(at: targetIndexPath, at: .centeredVertically, animated: false)
+        refreshVisibleListCells()
+        schedulePreview(for: items[targetIndex])
+        setNeedsFocusUpdate()
+        updateFocusIfNeeded()
+    }
+
+    private func resumePreviewIfNeeded() {
+        guard previewController == nil,
+              previewTask == nil,
+              presentedViewController == nil,
+              isViewLoaded,
+              view.window != nil,
+              !items.isEmpty
+        else { return }
+        let targetIndex = min(focusedIndex, items.count - 1)
+        schedulePreview(for: items[targetIndex])
+    }
+
+    private func enterFlow(at index: Int) {
+        guard items.indices.contains(index) else { return }
+        isPresentingFeedFlow = true
+        focusedIndex = index
+        sequenceProvider.setCurrentIndex(index)
+        lastPlayedItemIdentity = items[index].identityKey
+        let startTimeOverride = previewStartTimeForFlowEntry(at: index)
+        suspendPreview(cancelWarmups: false)
+        let player = VideoPlayerViewController(playInfo: items[index].playInfo,
+                                               playMode: .feedFlow,
+                                               playContextCache: playContextCache,
+                                               mediaWarmupManager: mediaWarmupManager,
+                                               startTimeOverride: startTimeOverride)
+        player.sequenceProvider = sequenceProvider
+        player.onPlayInfoChanged = { [weak self] info in
+            MainActor.callSafely {
+                self?.updateSelectionFromPlayInfo(info)
+            }
+        }
+        player.onDismissWithPlayInfo = { [weak self] info in
+            MainActor.callSafely {
+                self?.applyReturnedPlaybackSelection(info)
+            }
+        }
+        player.onItemWatched = { [weak self] playInfo, watchedSeconds in
+            self?.handleItemWatched(playInfo: playInfo, watchedSeconds: watchedSeconds)
+        }
+        present(player, animated: true)
+    }
+
+    private func previewStartTimeForFlowEntry(at index: Int) -> Int? {
+        guard let previewController,
+              items.indices.contains(index),
+              FeedFlowItem.identityKey(for: previewController.currentPlayInfo) == items[index].identityKey
+        else {
+            return nil
+        }
+        return previewController.currentPlaybackTimeInSeconds()
+    }
+
+    private func handleItemWatched(playInfo: PlayInfo, watchedSeconds: Int) {
+        let duration = playInfo.duration ?? 0
+        let isPositive = watchedSeconds >= 8 || (duration > 0 && Double(watchedSeconds) >= Double(duration) * 0.25)
+        guard isPositive else { return }
+        dataSource.didRecordPositiveWatchSignal(playInfo: playInfo, watchedSeconds: watchedSeconds)
+    }
+}
+
+extension FeedFlowBrowserViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        items.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FeedFlowListCell.reuseID, for: indexPath) as! FeedFlowListCell
+        cell.configure(with: items[indexPath.item], isCurrent: indexPath.item == focusedIndex)
+        return cell
+    }
+
+    func indexPathForPreferredFocusedView(in collectionView: UICollectionView) -> IndexPath? {
+        guard let targetIndex = resolvedSelectionIndex() else { return nil }
+        return IndexPath(item: targetIndex, section: 0)
+    }
+}
+
+extension FeedFlowBrowserViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        enterFlow(at: indexPath.item)
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        didUpdateFocusIn context: UICollectionViewFocusUpdateContext,
+                        with coordinator: UIFocusAnimationCoordinator)
+    {
+        guard let nextIndexPath = context.nextFocusedIndexPath,
+              items.indices.contains(nextIndexPath.item)
+        else { return }
+        focusedIndex = nextIndexPath.item
+        collectionView.selectItem(at: nextIndexPath, animated: true, scrollPosition: .centeredVertically)
+        sequenceProvider.setCurrentIndex(focusedIndex)
+        schedulePreview(for: items[focusedIndex])
+        refreshVisibleListCells()
+        if items.count - focusedIndex - 1 < dataSource.trailingPrefetchTargetCount {
+            Task {
+                await loadMoreItemsIfNeeded(targetCount: dataSource.trailingPrefetchTargetCount,
+                                            maxSourcePages: dataSource.trailingMaxSourcePages)
+            }
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        guard indexPath.item >= items.count - 4 else { return }
+        Task {
+            await loadMoreItemsIfNeeded(targetCount: dataSource.trailingPrefetchTargetCount,
+                                        maxSourcePages: dataSource.trailingMaxSourcePages)
+        }
+    }
+}

--- a/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowBrowserViewController.swift
@@ -696,9 +696,6 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
                 self?.applyReturnedPlaybackSelection(info)
             }
         }
-        player.onItemWatched = { [weak self] playInfo, watchedSeconds in
-            self?.handleItemWatched(playInfo: playInfo, watchedSeconds: watchedSeconds)
-        }
         present(player, animated: true)
     }
 
@@ -710,13 +707,6 @@ class FeedFlowBrowserViewController: UIViewController, BLTabBarContentVCProtocol
             return nil
         }
         return previewController.currentPlaybackTimeInSeconds()
-    }
-
-    private func handleItemWatched(playInfo: PlayInfo, watchedSeconds: Int) {
-        let duration = playInfo.duration ?? 0
-        let isPositive = watchedSeconds >= 8 || (duration > 0 && Double(watchedSeconds) >= Double(duration) * 0.25)
-        guard isPositive else { return }
-        dataSource.didRecordPositiveWatchSignal(playInfo: playInfo, watchedSeconds: watchedSeconds)
     }
 }
 

--- a/BilibiliLive/Module/ViewController/FeedFlowListCell.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowListCell.swift
@@ -1,0 +1,111 @@
+//
+//  FeedFlowListCell.swift
+//  BilibiliLive
+//
+
+import Kingfisher
+import SnapKit
+import UIKit
+
+final class FeedFlowListCell: BLMotionCollectionViewCell {
+    static let reuseID = String(describing: FeedFlowListCell.self)
+
+    private let blurBackgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
+    private let imageView = UIImageView()
+    private let titleLabel = UILabel()
+    private let metaLabel = UILabel()
+    private let overlayView = BLOverlayView()
+    private var isCurrent = false
+
+    override func setup() {
+        super.setup()
+        scaleFactor = 1.06
+
+        contentView.addSubview(blurBackgroundView)
+        blurBackgroundView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        blurBackgroundView.layer.cornerRadius = 20
+        blurBackgroundView.layer.cornerCurve = .continuous
+        blurBackgroundView.clipsToBounds = true
+
+        blurBackgroundView.contentView.addSubview(imageView)
+        imageView.snp.makeConstraints { make in
+            make.leading.top.bottom.equalToSuperview().inset(14)
+            make.width.equalTo(170)
+        }
+        imageView.layer.cornerRadius = 14
+        imageView.layer.cornerCurve = .continuous
+        imageView.clipsToBounds = true
+        imageView.contentMode = .scaleAspectFill
+
+        imageView.addSubview(overlayView)
+        overlayView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        overlayView.fontSize = 14
+
+        blurBackgroundView.contentView.addSubview(titleLabel)
+        blurBackgroundView.contentView.addSubview(metaLabel)
+
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(18)
+            make.leading.equalTo(imageView.snp.trailing).offset(18)
+            make.trailing.equalToSuperview().offset(-18)
+        }
+        titleLabel.font = .systemFont(ofSize: 28, weight: .semibold)
+        titleLabel.textColor = .white
+        titleLabel.numberOfLines = 2
+
+        metaLabel.snp.makeConstraints { make in
+            make.leading.equalTo(titleLabel)
+            make.trailing.equalTo(titleLabel)
+            make.bottom.equalToSuperview().offset(-18)
+        }
+        metaLabel.font = .systemFont(ofSize: 22, weight: .medium)
+        metaLabel.textColor = UIColor.white.withAlphaComponent(0.78)
+        metaLabel.numberOfLines = 1
+    }
+
+    func configure(with item: FeedFlowItem, isCurrent: Bool) {
+        titleLabel.text = item.title
+        metaLabel.text = item.listMetaText
+        self.isCurrent = isCurrent
+
+        if let coverURL = item.coverURL {
+            imageView.kf.setImage(with: coverURL)
+        } else {
+            imageView.image = nil
+        }
+
+        var leftItems = [DisplayOverlay.DisplayOverlayItem]()
+        var rightItems = [DisplayOverlay.DisplayOverlayItem]()
+        if !item.viewCountText.isEmpty && !item.viewCountText.contains(":") {
+            leftItems.append(DisplayOverlay.DisplayOverlayItem(icon: "play.rectangle",
+                                                               text: item.viewCountText.replacingOccurrences(of: "观看", with: "")))
+        } else if !item.danmakuCountText.isEmpty && !item.danmakuCountText.contains(":") {
+            leftItems.append(DisplayOverlay.DisplayOverlayItem(icon: "play.rectangle",
+                                                               text: item.danmakuCountText.replacingOccurrences(of: "观看", with: "")))
+        }
+        if !item.durationText.isEmpty {
+            rightItems.append(DisplayOverlay.DisplayOverlayItem(icon: nil, text: item.durationText))
+        }
+
+        overlayView.configure(DisplayOverlay(leftItems: leftItems, rightItems: rightItems))
+        overlayView.isHidden = leftItems.isEmpty && rightItems.isEmpty
+        updateAppearance()
+    }
+
+    override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        super.didUpdateFocus(in: context, with: coordinator)
+        coordinator.addCoordinatedAnimations {
+            self.updateAppearance()
+        }
+    }
+
+    private func updateAppearance() {
+        blurBackgroundView.effect = UIBlurEffect(style: isFocused || isCurrent ? .light : .dark)
+        titleLabel.textColor = isFocused || isCurrent ? .black : .white
+        metaLabel.textColor = isFocused || isCurrent ? UIColor.black.withAlphaComponent(0.75) : UIColor.white.withAlphaComponent(0.78)
+    }
+}

--- a/BilibiliLive/Module/ViewController/FeedFlowModels.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowModels.swift
@@ -1,0 +1,129 @@
+//
+//  FeedFlowModels.swift
+//  BilibiliLive
+//
+
+import Foundation
+
+struct FeedFlowItem: Hashable {
+    let identityKey: String
+    let aid: Int
+    let cid: Int?
+    let epid: Int?
+    let seasonId: Int?
+    let subType: Int?
+    let title: String
+    let ownerName: String
+    let coverURL: URL?
+    let avatarURL: URL?
+    let duration: Int?
+    let durationText: String
+    let viewCountText: String
+    let danmakuCountText: String
+    let reasonText: String?
+
+    init(aid: Int,
+         cid: Int? = nil,
+         epid: Int? = nil,
+         seasonId: Int? = nil,
+         subType: Int? = nil,
+         title: String,
+         ownerName: String,
+         coverURL: URL?,
+         avatarURL: URL? = nil,
+         duration: Int? = nil,
+         durationText: String = "",
+         viewCountText: String = "",
+         danmakuCountText: String = "",
+         reasonText: String? = nil,
+         identityKey: String? = nil)
+    {
+        self.aid = aid
+        self.cid = cid
+        self.epid = epid
+        self.seasonId = seasonId
+        self.subType = subType
+        self.title = title
+        self.ownerName = ownerName
+        self.coverURL = coverURL
+        self.avatarURL = avatarURL
+        self.duration = duration
+        self.durationText = durationText
+        self.viewCountText = viewCountText
+        self.danmakuCountText = danmakuCountText
+        self.reasonText = reasonText
+        self.identityKey = identityKey ?? Self.makeIdentityKey(aid: aid, epid: epid, seasonId: seasonId)
+    }
+
+    var playInfo: PlayInfo {
+        PlayInfo(aid: aid,
+                 cid: cid,
+                 epid: epid,
+                 seasonId: seasonId,
+                 subType: subType,
+                 title: title,
+                 ownerName: ownerName,
+                 coverURL: coverURL,
+                 duration: duration)
+    }
+
+    var metaText: String {
+        [ownerName, durationText]
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+
+    var listMetaText: String {
+        ownerName.isEmpty ? durationText : ownerName
+    }
+
+    static func makeIdentityKey(aid: Int, epid: Int? = nil, seasonId: Int? = nil) -> String {
+        if let epid, epid > 0 {
+            return "epid-\(epid)"
+        }
+        if let seasonId, seasonId > 0 {
+            return "season-\(seasonId)"
+        }
+        return "aid-\(aid)"
+    }
+
+    static func identityKey(for playInfo: PlayInfo) -> String {
+        makeIdentityKey(aid: playInfo.aid,
+                        epid: playInfo.epid,
+                        seasonId: playInfo.seasonId)
+    }
+}
+
+@MainActor
+protocol FeedFlowDataSource: AnyObject {
+    var title: String { get }
+    var reloadToken: String { get }
+    var autoReloadInterval: TimeInterval? { get }
+    var defaultPreviewHintText: String { get }
+    var loadingHintText: String { get }
+    var emptyStateText: String { get }
+    var emptyHintText: String { get }
+    var loadFailureText: String { get }
+    var initialTargetCount: Int { get }
+    var initialMaxSourcePages: Int { get }
+    var trailingPrefetchTargetCount: Int { get }
+    var trailingMaxSourcePages: Int { get }
+    func reset()
+    func refreshFromStart(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem]
+    func loadMoreItems(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem]
+    func didRecordPositiveWatchSignal(playInfo: PlayInfo, watchedSeconds: Int)
+}
+
+extension FeedFlowDataSource {
+    var autoReloadInterval: TimeInterval? { nil }
+    var defaultPreviewHintText: String { "停留后自动预览，按确认键进入视频流" }
+    var loadingHintText: String { "正在加载视频..." }
+    var emptyStateText: String { "当前视频较少，请稍后重试" }
+    var emptyHintText: String { "稍后再试" }
+    var loadFailureText: String { "加载失败，请稍后重试" }
+    var initialTargetCount: Int { 12 }
+    var initialMaxSourcePages: Int { 5 }
+    var trailingPrefetchTargetCount: Int { 8 }
+    var trailingMaxSourcePages: Int { 3 }
+    func didRecordPositiveWatchSignal(playInfo: PlayInfo, watchedSeconds: Int) {}
+}

--- a/BilibiliLive/Module/ViewController/FeedFlowModels.swift
+++ b/BilibiliLive/Module/ViewController/FeedFlowModels.swift
@@ -16,7 +16,6 @@ struct FeedFlowItem: Hashable {
     let ownerName: String
     let coverURL: URL?
     let avatarURL: URL?
-    let duration: Int?
     let durationText: String
     let viewCountText: String
     let danmakuCountText: String
@@ -31,7 +30,6 @@ struct FeedFlowItem: Hashable {
          ownerName: String,
          coverURL: URL?,
          avatarURL: URL? = nil,
-         duration: Int? = nil,
          durationText: String = "",
          viewCountText: String = "",
          danmakuCountText: String = "",
@@ -47,7 +45,6 @@ struct FeedFlowItem: Hashable {
         self.ownerName = ownerName
         self.coverURL = coverURL
         self.avatarURL = avatarURL
-        self.duration = duration
         self.durationText = durationText
         self.viewCountText = viewCountText
         self.danmakuCountText = danmakuCountText
@@ -63,8 +60,7 @@ struct FeedFlowItem: Hashable {
                  subType: subType,
                  title: title,
                  ownerName: ownerName,
-                 coverURL: coverURL,
-                 duration: duration)
+                 coverURL: coverURL)
     }
 
     var metaText: String {
@@ -111,7 +107,6 @@ protocol FeedFlowDataSource: AnyObject {
     func reset()
     func refreshFromStart(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem]
     func loadMoreItems(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem]
-    func didRecordPositiveWatchSignal(playInfo: PlayInfo, watchedSeconds: Int)
 }
 
 extension FeedFlowDataSource {
@@ -125,5 +120,4 @@ extension FeedFlowDataSource {
     var initialMaxSourcePages: Int { 5 }
     var trailingPrefetchTargetCount: Int { 8 }
     var trailingMaxSourcePages: Int { 3 }
-    func didRecordPositiveWatchSignal(playInfo: PlayInfo, watchedSeconds: Int) {}
 }

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -20,6 +20,22 @@ enum ValidationError: Error {
     case argumentInvalid(message: String)
 }
 
+struct PlayURLRequestOptions: Hashable {
+    let qn: Int
+    let fnval: Int
+    let enableFourK: Bool
+    let supportMultiAudio: Bool
+
+    static let regular = PlayURLRequestOptions(qn: 127,
+                                               fnval: 976,
+                                               enableFourK: true,
+                                               supportMultiAudio: true)
+    static let featuredPreview = PlayURLRequestOptions(qn: 64,
+                                                       fnval: 16,
+                                                       enableFourK: false,
+                                                       supportMultiAudio: false)
+}
+
 enum NoCookieSession {
     static let session = Session(configuration: URLSessionConfiguration.ephemeral)
 }
@@ -461,29 +477,56 @@ extension WebRequest {
         }
     }
 
-    static func requestPlayUrl(aid: Int, cid: Int) async throws -> VideoPlayURLInfo {
-        // 始终请求最高画质 (fnval=976 支持杜比视界和8K, qn=127 请求8K)
-        // 这样可以获取所有可用的画质流，由播放器或用户选择
+    static func requestPlayUrl(aid: Int, cid: Int, options: PlayURLRequestOptions = .regular) async throws -> VideoPlayURLInfo {
         return try await request(url: EndPoint.playUrl,
-                                 parameters: ["avid": aid, "cid": cid, "qn": 127, "type": "", "fnver": 0, "fnval": 976, "otype": "json"])
+                                 parameters: ["avid": aid,
+                                              "cid": cid,
+                                              "qn": options.qn,
+                                              "type": "",
+                                              "fnver": 0,
+                                              "fnval": options.fnval,
+                                              "otype": "json"])
     }
 
-    static func requestPcgPlayUrl(aid: Int, cid: Int) async throws -> VideoPlayURLInfo {
-        // 始终请求最高画质 (fnval=976 支持杜比视界和8K, qn=127 请求8K)
-        // 这样可以获取所有可用的画质流，由播放器或用户选择
+    static func requestPcgPlayUrl(aid: Int, cid: Int, options: PlayURLRequestOptions = .regular) async throws -> VideoPlayURLInfo {
+        var parameters: [String: Any] = ["avid": aid,
+                                         "cid": cid,
+                                         "qn": options.qn,
+                                         "fnver": 0,
+                                         "fnval": options.fnval]
+        if options.supportMultiAudio {
+            parameters["support_multi_audio"] = true
+        }
+        if options.enableFourK {
+            parameters["fourk"] = 1
+        }
         return try await request(url: EndPoint.pcgPlayUrl,
-                                 parameters: ["avid": aid, "cid": cid, "qn": 127, "support_multi_audio": true, "fnver": 0, "fnval": 976, "fourk": 1],
+                                 parameters: parameters,
                                  dataObj: "result")
     }
 
-    static func requestAreaLimitPcgPlayUrl(epid: Int, cid: Int, area: String) async throws -> VideoPlayURLInfo {
+    static func requestAreaLimitPcgPlayUrl(epid: Int,
+                                           cid: Int,
+                                           area: String,
+                                           options: PlayURLRequestOptions = .regular) async throws -> VideoPlayURLInfo
+    {
         let customServer = Settings.areaLimitCustomServer
         guard !customServer.isEmpty else { throw ValidationError.argumentInvalid(message: "未设置解析服务器") }
 
         // 解析服务器必须使用ep_id参数，不能使用avid参数，解析服务器一般有缓存，area和ep_id必须保持一致，要不然会被缓存拦截
         let url = EndPoint.pcgPlayUrl.replacingOccurrences(of: "api.bilibili.com", with: customServer)
-        // 始终请求最高画质 (fnval=976 支持杜比视界和8K, qn=127 请求8K)
-        var parameters: [String: Any] = ["ep_id": epid, "cid": cid, "qn": 127, "support_multi_audio": 1, "fnver": 0, "fnval": 976, "fourk": 1, "area": area]
+        var parameters: [String: Any] = ["ep_id": epid,
+                                         "cid": cid,
+                                         "qn": options.qn,
+                                         "fnver": 0,
+                                         "fnval": options.fnval,
+                                         "area": area]
+        if options.supportMultiAudio {
+            parameters["support_multi_audio"] = 1
+        }
+        if options.enableFourK {
+            parameters["fourk"] = 1
+        }
         if let access_key = ApiRequest.getToken()?.accessToken {
             parameters["access_key"] = access_key
         }


### PR DESCRIPTION
## 改动说明

- 抽取新推荐体验共用的全屏沉浸式播放流程。
- 将 SIDX 状态限制在各自的资源加载会话中，避免普通播放、画中画等并发场景共享可变状态。
- 保留 AVInfoPanel 焦点 Hook，并处理 Hook 较晚安装时首次聚焦失效的问题；诊断日志仅在 DEBUG 构建中输出。
- 删除冗余流程代码，完善过期请求和相邻视频预加载的取消逻辑。

## 功能开关

这是多个功能共用的基础能力，不增加面向用户的独立开关。

## 验证

- tvOS Simulator Debug 构建通过。
- 项目当前没有自动化测试套件。

## 合并说明

建议使用 **Create a merge commit** 合并。后续功能分支共享本 PR 的基础提交，需要保留提交关系以维持清晰的差异。

## 原作者与贡献说明

本 PR 所拆分功能的原始实现来自 @hugohua 的 #195（原始提交 d4f6b27）。本 PR 在此基础上进行了功能拆分、精简、重构与修复。