### PR TITLE
功能：在现有推荐页中加入 Featured 展示模式

### DIFF
--- a/BilibiliLive/Component/Settings.swift
+++ b/BilibiliLive/Component/Settings.swift
@@ -105,6 +105,12 @@ enum Settings {
     @UserDefault("Settings.ui.sideMenuAutoSelectChange", defaultValue: false)
     static var sideMenuAutoSelectChange: Bool
 
+    @UserDefaultCodable("Settings.featuredDurationLimit", defaultValue: .minutes10)
+    static var featuredDurationLimit: FeaturedDurationLimit
+
+    @UserDefault("Settings.recommendFeedFlowEnabled", defaultValue: false)
+    static var recommendFeedFlowEnabled: Bool
+
     @UserDefaultCodable("Settings.SponsorBlockType", defaultValue: SponsorBlockType.none)
     static var enableSponsorBlock: SponsorBlockType
 
@@ -282,6 +288,46 @@ extension DanmuArea {
             return 0.25
         case .style_0:
             return 1
+        }
+    }
+}
+
+enum FeaturedDurationLimit: Codable, CaseIterable, Equatable {
+    case minutes3
+    case minutes5
+    case minutes10
+    case minutes15
+    case unlimited
+}
+
+extension FeaturedDurationLimit {
+    var title: String {
+        switch self {
+        case .minutes3:
+            return "3 分钟"
+        case .minutes5:
+            return "5 分钟"
+        case .minutes10:
+            return "10 分钟"
+        case .minutes15:
+            return "15 分钟"
+        case .unlimited:
+            return "不限"
+        }
+    }
+
+    var maxDuration: Int? {
+        switch self {
+        case .minutes3:
+            return 3 * 60
+        case .minutes5:
+            return 5 * 60
+        case .minutes10:
+            return 10 * 60
+        case .minutes15:
+            return 15 * 60
+        case .unlimited:
+            return nil
         }
     }
 }

--- a/BilibiliLive/Module/Personal/SettingsViewController.swift
+++ b/BilibiliLive/Module/Personal/SettingsViewController.swift
@@ -150,6 +150,19 @@ class SettingsViewController: UIViewController {
                 }
             }
 
+            SectionModel(title: "推荐") {
+                Toggle(title: "使用沉浸式浏览模式",
+                       setting: Settings.recommendFeedFlowEnabled,
+                       onChange: Settings.recommendFeedFlowEnabled.toggle())
+                Actions(title: "沉浸式视频时长上限", message: "用于筛选沉浸式推荐中的短视频",
+                        current: Settings.featuredDurationLimit.title,
+                        options: FeaturedDurationLimit.allCases,
+                        optionString: FeaturedDurationLimit.allCases.map { $0.title })
+                {
+                    Settings.featuredDurationLimit = $0
+                }
+            }
+
             SectionModel(title: "音视频") {
                 Actions(title: "最高画质", message: "4k以上需要大会员",
                         current: Settings.mediaQuality.desp,

--- a/BilibiliLive/Module/Tabbar/TabBarPageFactory.swift
+++ b/BilibiliLive/Module/Tabbar/TabBarPageFactory.swift
@@ -14,7 +14,7 @@ class TabBarPageVCFactory {
         case .live:
             vc = LiveViewController()
         case .feed:
-            vc = FeedViewController()
+            vc = RecommendViewController()
         case .hot:
             vc = HotViewController()
         case .ranking:

--- a/BilibiliLive/Module/ViewController/FeaturedBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeaturedBrowserViewController.swift
@@ -1,0 +1,121 @@
+import Foundation
+import UIKit
+
+private extension ApiRequest.FeedResp.Items {
+    func toFeaturedFeedFlowItem(durationLimit: FeaturedDurationLimit) -> FeedFlowItem? {
+        guard goto == "av", can_play == 1 else { return nil }
+
+        let aidValue = Int(param) ?? player_args?.aid ?? 0
+        let cidValue = player_args?.cid ?? 0
+        let durationValue = player_args?.duration ?? 0
+        guard aidValue > 0, cidValue > 0, durationValue > 0 else { return nil }
+        if let maxDuration = durationLimit.maxDuration, durationValue > maxDuration {
+            return nil
+        }
+
+        return FeedFlowItem(aid: aidValue,
+                            cid: cidValue,
+                            title: title,
+                            ownerName: ownerName,
+                            coverURL: pic,
+                            avatarURL: avatar,
+                            duration: durationValue,
+                            durationText: cover_right_text ?? TimeInterval(durationValue).timeString(),
+                            viewCountText: cover_left_text_1 ?? "",
+                            danmakuCountText: cover_left_text_2 ?? "",
+                            reasonText: top_rcmd_reason ?? bottom_rcmd_reason)
+    }
+}
+
+final class FeaturedBrowserViewController: FeedFlowBrowserViewController {
+    init() {
+        super.init(dataSource: FeaturedFeedFlowDataSource())
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
+    let title = "推荐"
+    let defaultPreviewHintText = "停留后自动预览，按确认键进入短视频流"
+    let loadingHintText = "正在加载沉浸式推荐..."
+    let emptyStateText = "当前可播放的短视频较少，请稍后重试"
+    let emptyHintText = "可以在设置里调整沉浸式视频时长上限"
+    let loadFailureText = "推荐加载失败，请稍后重试"
+
+    var reloadToken: String { Settings.featuredDurationLimit.title }
+
+    private var durationLimit = Settings.featuredDurationLimit
+    private var lastSourceIdx: Int?
+    private var seenItemKeys = Set<String>()
+
+    func reset() {
+        durationLimit = Settings.featuredDurationLimit
+        lastSourceIdx = nil
+        seenItemKeys = []
+    }
+
+    func refreshFromStart(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem] {
+        let requestDurationLimit = durationLimit
+        var loadedItems = [FeedFlowItem]()
+        var nextSourceIdx: Int?
+        var pagesScanned = 0
+        var seenKeys = Set<String>()
+
+        while loadedItems.count < targetCount, pagesScanned < maxSourcePages {
+            try Task.checkCancellation()
+            let requestedSourceIdx = nextSourceIdx
+            let sourceItems: [ApiRequest.FeedResp.Items]
+            if let nextSourceIdx {
+                sourceItems = try await ApiRequest.getFeeds(lastIdx: nextSourceIdx)
+            } else {
+                sourceItems = try await ApiRequest.getFeeds()
+            }
+            try Task.checkCancellation()
+            pagesScanned += 1
+            nextSourceIdx = sourceItems.last?.idx
+            loadedItems.append(contentsOf: sourceItems
+                .compactMap { $0.toFeaturedFeedFlowItem(durationLimit: requestDurationLimit) }
+                .filter { seenKeys.insert($0.identityKey).inserted })
+            if sourceItems.isEmpty || nextSourceIdx == requestedSourceIdx {
+                break
+            }
+        }
+
+        try Task.checkCancellation()
+        lastSourceIdx = nextSourceIdx
+        seenItemKeys = seenKeys
+        return loadedItems
+    }
+
+    func loadMoreItems(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem] {
+        let requestDurationLimit = durationLimit
+        var accepted = [FeedFlowItem]()
+        var pagesScanned = 0
+        var nextSourceIdx = lastSourceIdx
+        var seenKeys = seenItemKeys
+
+        while accepted.count < targetCount, pagesScanned < maxSourcePages {
+            try Task.checkCancellation()
+            let requestedSourceIdx = nextSourceIdx
+            let sourceItems = try await ApiRequest.getFeeds(lastIdx: nextSourceIdx ?? 0)
+            try Task.checkCancellation()
+            pagesScanned += 1
+            nextSourceIdx = sourceItems.last?.idx
+            accepted.append(contentsOf: sourceItems
+                .compactMap { $0.toFeaturedFeedFlowItem(durationLimit: requestDurationLimit) }
+                .filter { seenKeys.insert($0.identityKey).inserted })
+            if sourceItems.isEmpty || nextSourceIdx == requestedSourceIdx {
+                break
+            }
+        }
+
+        try Task.checkCancellation()
+        lastSourceIdx = nextSourceIdx
+        seenItemKeys = seenKeys
+        return accepted
+    }
+}

--- a/BilibiliLive/Module/ViewController/FeaturedBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeaturedBrowserViewController.swift
@@ -51,11 +51,13 @@ final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
     private var durationLimit = Settings.featuredDurationLimit
     private var lastSourceIdx: Int?
     private var seenItemKeys = Set<String>()
+    private var hasMore = true
 
     func reset() {
         durationLimit = Settings.featuredDurationLimit
         lastSourceIdx = nil
         seenItemKeys = []
+        hasMore = true
     }
 
     func refreshFromStart(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem] {
@@ -64,6 +66,7 @@ final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
         var nextSourceIdx: Int?
         var pagesScanned = 0
         var seenKeys = Set<String>()
+        var reachedEnd = false
 
         while loadedItems.count < targetCount, pagesScanned < maxSourcePages {
             try Task.checkCancellation()
@@ -76,11 +79,16 @@ final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
             }
             try Task.checkCancellation()
             pagesScanned += 1
-            nextSourceIdx = sourceItems.last?.idx
+            guard let pageLastIdx = sourceItems.last?.idx else {
+                reachedEnd = true
+                break
+            }
+            nextSourceIdx = pageLastIdx
             loadedItems.append(contentsOf: sourceItems
                 .compactMap { $0.toFeaturedFeedFlowItem(durationLimit: requestDurationLimit) }
                 .filter { seenKeys.insert($0.identityKey).inserted })
-            if sourceItems.isEmpty || nextSourceIdx == requestedSourceIdx {
+            if nextSourceIdx == requestedSourceIdx {
+                reachedEnd = true
                 break
             }
         }
@@ -88,15 +96,18 @@ final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
         try Task.checkCancellation()
         lastSourceIdx = nextSourceIdx
         seenItemKeys = seenKeys
+        hasMore = !reachedEnd
         return loadedItems
     }
 
     func loadMoreItems(targetCount: Int, maxSourcePages: Int) async throws -> [FeedFlowItem] {
+        guard hasMore else { return [] }
         let requestDurationLimit = durationLimit
         var accepted = [FeedFlowItem]()
         var pagesScanned = 0
         var nextSourceIdx = lastSourceIdx
         var seenKeys = seenItemKeys
+        var reachedEnd = false
 
         while accepted.count < targetCount, pagesScanned < maxSourcePages {
             try Task.checkCancellation()
@@ -104,11 +115,16 @@ final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
             let sourceItems = try await ApiRequest.getFeeds(lastIdx: nextSourceIdx ?? 0)
             try Task.checkCancellation()
             pagesScanned += 1
-            nextSourceIdx = sourceItems.last?.idx
+            guard let pageLastIdx = sourceItems.last?.idx else {
+                reachedEnd = true
+                break
+            }
+            nextSourceIdx = pageLastIdx
             accepted.append(contentsOf: sourceItems
                 .compactMap { $0.toFeaturedFeedFlowItem(durationLimit: requestDurationLimit) }
                 .filter { seenKeys.insert($0.identityKey).inserted })
-            if sourceItems.isEmpty || nextSourceIdx == requestedSourceIdx {
+            if nextSourceIdx == requestedSourceIdx {
+                reachedEnd = true
                 break
             }
         }
@@ -116,6 +132,7 @@ final class FeaturedFeedFlowDataSource: FeedFlowDataSource {
         try Task.checkCancellation()
         lastSourceIdx = nextSourceIdx
         seenItemKeys = seenKeys
+        hasMore = !reachedEnd
         return accepted
     }
 }

--- a/BilibiliLive/Module/ViewController/FeaturedBrowserViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeaturedBrowserViewController.swift
@@ -19,7 +19,6 @@ private extension ApiRequest.FeedResp.Items {
                             ownerName: ownerName,
                             coverURL: pic,
                             avatarURL: avatar,
-                            duration: durationValue,
                             durationText: cover_right_text ?? TimeInterval(durationValue).timeString(),
                             viewCountText: cover_left_text_1 ?? "",
                             danmakuCountText: cover_left_text_2 ?? "",

--- a/BilibiliLive/Module/ViewController/FeedViewController.swift
+++ b/BilibiliLive/Module/ViewController/FeedViewController.swift
@@ -26,5 +26,5 @@ class FeedViewController: StandardVideoCollectionViewController<ApiRequest.FeedR
 
 extension ApiRequest.FeedResp.Items: PlayableData {
     var aid: Int { Int(param) ?? 0 }
-    var cid: Int { 0 }
+    var cid: Int { player_args?.cid ?? 0 }
 }

--- a/BilibiliLive/Module/ViewController/RecommendViewController.swift
+++ b/BilibiliLive/Module/ViewController/RecommendViewController.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+/// Keeps the existing recommendation tab stable while switching its presentation.
+final class RecommendViewController: UIViewController, BLTabBarContentVCProtocol {
+    private var activeMode: Bool?
+    private var contentViewController: UIViewController?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        updateContentIfNeeded()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateContentIfNeeded()
+    }
+
+    override var preferredFocusEnvironments: [any UIFocusEnvironment] {
+        contentViewController.map { [$0] } ?? super.preferredFocusEnvironments
+    }
+
+    func reloadData() {
+        (contentViewController as? BLTabBarContentVCProtocol)?.reloadData()
+    }
+
+    private func updateContentIfNeeded() {
+        let usesFeedFlow = Settings.recommendFeedFlowEnabled
+        guard activeMode != usesFeedFlow else { return }
+
+        let next = usesFeedFlow ? FeaturedBrowserViewController() : FeedViewController()
+        contentViewController?.willMove(toParent: nil)
+        contentViewController?.view.removeFromSuperview()
+        contentViewController?.removeFromParent()
+
+        addChild(next)
+        next.view.frame = view.bounds
+        next.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(next.view)
+        next.didMove(toParent: self)
+
+        contentViewController = next
+        activeMode = usesFeedFlow
+    }
+}

--- a/BilibiliLive/Request/ApiRequest.swift
+++ b/BilibiliLive/Request/ApiRequest.swift
@@ -260,6 +260,7 @@ enum ApiRequest {
             let param: String
             let args: Args
             let avatar_info: Avatar
+            let player_args: PlayerArgs?
             let idx: Int
             let cover: String
             let goto: String
@@ -269,10 +270,11 @@ enum ApiRequest {
             let cover_left_text_1: String?
             let cover_left_text_2: String?
             let cover_left_text_3: String?
+            let cover_right_text: String?
 
             enum CodingKeys: String, CodingKey {
-                case can_play, title, param, args, idx, cover, goto, top_rcmd_reason, bottom_rcmd_reason, desc
-                case cover_left_text_1, cover_left_text_2, cover_left_text_3
+                case can_play, title, param, args, idx, cover, goto, top_rcmd_reason, bottom_rcmd_reason, desc, player_args
+                case cover_left_text_1, cover_left_text_2, cover_left_text_3, cover_right_text
                 case avatar_info = "avatar"
             }
 
@@ -301,13 +303,13 @@ enum ApiRequest {
             var overlay: DisplayOverlay? {
                 var leftItems = [DisplayOverlay.DisplayOverlayItem]()
                 var rightItems = [DisplayOverlay.DisplayOverlayItem]()
-                if let text = cover_left_text_2 {
+                if let text = cover_left_text_1 {
                     leftItems.append(DisplayOverlay.DisplayOverlayItem(icon: "play.rectangle", text: text))
                 }
-                if let text = cover_left_text_3 {
+                if let text = cover_left_text_2 {
                     leftItems.append(DisplayOverlay.DisplayOverlayItem(icon: "list.bullet.rectangle", text: text))
                 }
-                if let text = cover_left_text_1 {
+                if let text = cover_right_text ?? cover_left_text_3 {
                     rightItems.append(DisplayOverlay.DisplayOverlayItem(icon: nil, text: text))
                 }
                 return DisplayOverlay(leftItems: leftItems, rightItems: rightItems)
@@ -321,6 +323,46 @@ enum ApiRequest {
 
         struct Avatar: Codable, Hashable {
             let cover: String?
+        }
+
+        struct PlayerArgs: Codable, Hashable {
+            let aid: Int?
+            let cid: Int?
+            let duration: Int?
+            let type: String?
+
+            enum CodingKeys: String, CodingKey {
+                case aid, cid, duration, type
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                if let intVal = try? container.decodeIfPresent(Int.self, forKey: .aid) {
+                    aid = intVal
+                } else if let stringVal = try? container.decodeIfPresent(String.self, forKey: .aid) {
+                    aid = Int(stringVal)
+                } else {
+                    aid = nil
+                }
+
+                if let intVal = try? container.decodeIfPresent(Int.self, forKey: .cid) {
+                    cid = intVal
+                } else if let stringVal = try? container.decodeIfPresent(String.self, forKey: .cid) {
+                    cid = Int(stringVal)
+                } else {
+                    cid = nil
+                }
+
+                if let intVal = try? container.decodeIfPresent(Int.self, forKey: .duration) {
+                    duration = intVal
+                } else if let stringVal = try? container.decodeIfPresent(String.self, forKey: .duration) {
+                    duration = Int(stringVal)
+                } else {
+                    duration = nil
+                }
+
+                type = try? container.decodeIfPresent(String.self, forKey: .type)
+            }
         }
     }
 


### PR DESCRIPTION
## 改动说明

- 将 Featured 作为现有推荐页中的可选沉浸式展示模式，而不是新增顶层页面。
- 正确保留分页结束状态，并删除未使用的播放时长相关代码。
- 删除 Featured 列表本地缓存、兴趣画像持久化和本地个性化重排。

## 功能开关

在设置中提供开关，用于切换现有推荐页是否采用 Featured 展示模式。

## 依赖关系

本 PR 基于 #211。#211 合入后，需要将本 PR 的 base 调整为 main。

## 验证

- 已在整合分支中通过 tvOS Simulator Debug 构建。
- 项目当前没有自动化测试套件。

## 合并说明

建议使用 **Create a merge commit** 合并，因为安全过滤 PR 基于本 PR 的功能提交。

## 原作者与贡献说明

本 PR 所拆分功能的原始实现来自 @hugohua 的 #195（原始提交 d4f6b27）。本 PR 在此基础上进行了功能拆分、精简、重构与修复。